### PR TITLE
Auto-import and synchronize GNOME Online Accounts

### DIFF
--- a/accounts.toml.example
+++ b/accounts.toml.example
@@ -15,8 +15,12 @@ name = "Personal"
 email = "you@example.com"
 imap_host = "imap.example.com"
 imap_port = 993            # optional, defaults to 993 (implicit TLS)
+# imap_starttls = true     # use with port 143; credentials are sent only after STARTTLS
+# imap_implicit_tls = true # only needed for implicit TLS on a custom port
 smtp_host = "smtp.example.com"  # optional, derived from imap_host if omitted
 smtp_port = 587            # optional, defaults to 587 (STARTTLS; use 465 for implicit TLS)
+# smtp_implicit_tls = true # only needed for implicit TLS on a custom port
+# smtp_auth = true         # optional, defaults to authenticated SMTP
 username = "you@example.com"
 password = "app-specific-password"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -298,9 +298,8 @@ pub enum AppMsg {
     AccountRemoved { email: String },
     AccountEnabledChanged { email: String, enabled: bool },
     ImportGoaAccount(Box<AccountConfig>),
-    /// GNOME Online Accounts changed on the session bus — re-reconcile and drop
-    /// any imported account whose GOA account was removed.
-    GoaChanged,
+    /// Background GOA snapshot after a debounced session-bus change.
+    GoaChanged(Box<crate::goa::GoaSnapshot>),
     /// The system resumed from sleep — worker IMAP sockets are stale, so
     /// reconnect every account and reload the visible folder.
     SystemResumed,
@@ -666,9 +665,31 @@ impl SimpleComponent for AppModel {
         // Accounts no longer has (removed or Mail-disabled there). Reconciliation
         // is skipped when GOA is unreachable, so a momentary outage never wipes
         // imported accounts. Live changes are handled by the watcher below.
+        let accounts_parseable = config::accounts_file_is_parseable();
         let mut config = config::load().unwrap_or_default();
-        let goa_removed = reconcile_goa(&mut config);
-        if !goa_removed.is_empty() {
+        let (goa_removed, goa_sync) = if accounts_parseable {
+            if let Some(snapshot) = crate::goa::snapshot() {
+                (
+                    reconcile_goa(&mut config, &snapshot.account_ids),
+                    sync_goa_accounts(
+                        &mut config,
+                        &snapshot.accounts,
+                        &snapshot.disabled_mail_ids,
+                    ),
+                )
+            } else {
+                (Vec::new(), GoaSync::default())
+            }
+        } else {
+            (Vec::new(), GoaSync::default())
+        };
+        if !goa_removed.is_empty() || goa_sync.changed {
+            migrate_sidebar_emails(
+                &mut sidebar_state.order,
+                &mut sidebar_state.collapsed,
+                &mut sidebar_state.folders_expanded,
+                &goa_sync.renamed,
+            );
             for email in &goa_removed {
                 config::delete_password(email);
             }
@@ -677,6 +698,9 @@ impl SimpleComponent for AppModel {
             sidebar_state.folders_expanded.retain(|e| !goa_removed.contains(e));
             let _ = config::save(&config);
             config::save_sidebar_state(&sidebar_state);
+        }
+        if goa_sync.imported > 0 {
+            tracing::info!("automatically imported {} GNOME Online Account(s)", goa_sync.imported);
         }
         let order = sidebar_state.order;
         let collapsed = sidebar_state.collapsed;
@@ -826,14 +850,20 @@ impl SimpleComponent for AppModel {
             gallery_by_account: HashMap::new(),
         };
         model.spawn_workers(&sender);
-        // Watch GNOME Online Accounts so an account removed there disappears from
-        // Vireo live (no restart needed); reconciliation happens on GoaChanged.
-        crate::goa::watch_removals({
-            let s = sender.input_sender().clone();
-            move || {
-                let _ = s.send(AppMsg::GoaChanged);
-            }
-        });
+        // Mirror Geary's GOA behaviour: newly added accounts appear immediately,
+        // while removed accounts disappear without an app restart.
+        if accounts_parseable {
+            crate::goa::watch_changes({
+                let s = sender.input_sender().clone();
+                move || {
+                    // The watcher callback runs on its dispatcher thread, keeping
+                    // blocking D-Bus work off GTK's main thread.
+                    if let Some(snapshot) = crate::goa::snapshot() {
+                        let _ = s.send(AppMsg::GoaChanged(Box::new(snapshot)));
+                    }
+                }
+            });
+        }
         // Watch for resume-from-sleep: suspended IMAP sockets die silently, so
         // on wake we reconnect every worker and refresh, otherwise no new mail
         // arrives until the app is restarted.
@@ -1849,12 +1879,20 @@ impl SimpleComponent for AppModel {
                 self.reconnect_all(&sender);
             }
 
-            AppMsg::GoaChanged => {
-                // A GOA account was removed/disabled in GNOME Settings. Drop any
-                // imported account that no longer exists there. (Adding an account
-                // to GOA never auto-imports — that stays a manual choice.)
-                let removed = reconcile_goa(&mut self.config);
-                if !removed.is_empty() {
+            AppMsg::GoaChanged(snapshot) => {
+                let removed = reconcile_goa(&mut self.config, &snapshot.account_ids);
+                let sync = sync_goa_accounts(
+                    &mut self.config,
+                    &snapshot.accounts,
+                    &snapshot.disabled_mail_ids,
+                );
+                if !removed.is_empty() || sync.changed {
+                    migrate_sidebar_emails(
+                        &mut self.account_order,
+                        &mut self.collapsed,
+                        &mut self.folders_expanded,
+                        &sync.renamed,
+                    );
                     for email in &removed {
                         config::delete_password(email);
                         self.account_order.retain(|e| e != email);
@@ -2333,7 +2371,7 @@ impl AppModel {
             }
         } else {
             for (i, account) in self.config.iter().enumerate() {
-                if !account.enabled {
+                if !account.enabled || account.goa_mail_disabled {
                     continue;
                 }
                 let account_id = i as u32 + 1;
@@ -4134,14 +4172,100 @@ fn demo_mode() -> bool {
     std::env::var_os("VIREO_DEMO").is_some()
 }
 
-/// Drop imported accounts whose GNOME Online Account no longer exists (removed or
-/// Mail-disabled in GNOME Settings), returning the emails dropped. Keeps every
-/// account — a no-op — when GOA can't be reached, so a momentarily-unavailable GOA
-/// never wipes imported accounts.
-fn reconcile_goa(config: &mut Vec<AccountConfig>) -> Vec<String> {
-    let Some(live) = crate::goa::live_account_ids() else {
-        return Vec::new();
-    };
+fn migrate_sidebar_emails(
+    order: &mut Vec<String>,
+    collapsed: &mut Vec<String>,
+    folders_expanded: &mut Vec<String>,
+    renamed: &[(String, String)],
+) {
+    for (old, new) in renamed {
+        for list in [&mut *order, &mut *collapsed, &mut *folders_expanded] {
+            for email in list.iter_mut() {
+                if email == old {
+                    *email = new.clone();
+                }
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct GoaSync {
+    changed: bool,
+    imported: usize,
+    renamed: Vec<(String, String)>,
+}
+
+/// Import every previously unseen mail-enabled GOA account and refresh GOA-owned
+/// connection settings on existing ones. GOA is authoritative for servers and
+/// authentication; Vireo retains local presentation choices and enabled state.
+fn sync_goa_accounts(
+    config: &mut Vec<AccountConfig>,
+    accounts: &[crate::goa::GoaMailAccount],
+    disabled_mail_ids: &std::collections::HashSet<String>,
+) -> GoaSync {
+    let mut result = GoaSync::default();
+    // Mail disabled in GNOME Settings pauses the account without deleting local
+    // signatures, colours or sidebar state. Remember whether it was enabled so
+    // re-enabling Mail can restore only accounts Vireo paused itself.
+    for existing in config.iter_mut() {
+        let Some(id) = existing.goa_id.as_ref() else {
+            continue;
+        };
+        if disabled_mail_ids.contains(id) && !existing.goa_mail_disabled {
+            existing.goa_enabled_before_mail_disabled = existing.enabled;
+            existing.enabled = false;
+            existing.goa_mail_disabled = true;
+            result.changed = true;
+        }
+    }
+    for goa in accounts {
+        // Like Geary, prefer OAuth when GOA exposes both auth interfaces.
+        let mut fresh = goa.to_config(String::new(), String::new(), goa.oauth2);
+        if let Some(index) = config
+            .iter()
+            .position(|c| c.goa_id.as_deref() == Some(goa.id.as_str()))
+        {
+            let old = &config[index];
+            fresh.enabled = if old.goa_mail_disabled {
+                old.goa_enabled_before_mail_disabled
+            } else {
+                old.enabled
+            };
+            fresh.goa_mail_disabled = false;
+            fresh.goa_enabled_before_mail_disabled = false;
+            fresh.name = old.name.clone();
+            fresh.color = old.color.clone();
+            fresh.emoji = old.emoji.clone();
+            fresh.signature = old.signature.clone();
+            fresh.signature_html = old.signature_html;
+            fresh.label = old.label.clone();
+            if *old != fresh {
+                if old.email != fresh.email {
+                    result.renamed.push((old.email.clone(), fresh.email.clone()));
+                }
+                config[index] = fresh;
+                result.changed = true;
+            }
+        } else if !config
+            .iter()
+            .any(|c| c.email.eq_ignore_ascii_case(&goa.email))
+        {
+            config.push(fresh);
+            result.changed = true;
+            result.imported += 1;
+        }
+    }
+    result
+}
+
+/// Drop imported accounts whose GNOME Online Account no longer exists, returning
+/// the emails dropped. Keeps every account when GOA can't be reached, so a
+/// momentarily-unavailable daemon never wipes imported accounts.
+fn reconcile_goa(
+    config: &mut Vec<AccountConfig>,
+    live: &std::collections::HashSet<String>,
+) -> Vec<String> {
     let mut removed = Vec::new();
     config.retain(|c| match &c.goa_id {
         Some(id) if !live.contains(id) => {
@@ -4479,5 +4603,102 @@ mod tests {
     #[test]
     fn search_pool_is_empty_when_nothing_indexed() {
         assert!(build_search_pool(&HashMap::new()).is_empty());
+    }
+
+    fn goa_account() -> crate::goa::GoaMailAccount {
+        crate::goa::GoaMailAccount {
+            id: "goa-1".into(),
+            email: "user@example.com".into(),
+            name: "GOA Name".into(),
+            provider: "Provider".into(),
+            imap_host: "imap.example.com".into(),
+            imap_port: 143,
+            imap_starttls: true,
+            imap_implicit_tls: false,
+            imap_user: "incoming".into(),
+            smtp_host: "smtp.example.com".into(),
+            smtp_port: 587,
+            smtp_implicit_tls: false,
+            smtp_user: "outgoing".into(),
+            smtp_auth: true,
+            password_based: true,
+            oauth2: false,
+        }
+    }
+
+    #[test]
+    fn goa_sync_imports_then_preserves_local_presentation() {
+        let mut config = Vec::new();
+        let account = goa_account();
+        let first = sync_goa_accounts(
+            &mut config,
+            std::slice::from_ref(&account),
+            &std::collections::HashSet::new(),
+        );
+        assert!(first.changed);
+        assert_eq!(first.imported, 1);
+        assert!(config[0].password.is_empty());
+
+        config[0].name = "Local Sender Name".into();
+        config[0].label = Some("Work".into());
+        config[0].enabled = false;
+        let mut changed = account;
+        changed.imap_host = "new.example.com".into();
+        let second = sync_goa_accounts(
+            &mut config,
+            &[changed],
+            &std::collections::HashSet::new(),
+        );
+        assert!(second.changed);
+        assert_eq!(config[0].imap_host, "new.example.com");
+        assert_eq!(config[0].name, "Local Sender Name");
+        assert_eq!(config[0].label.as_deref(), Some("Work"));
+        assert!(!config[0].enabled);
+    }
+
+    #[test]
+    fn goa_mail_disable_preserves_then_restores_account() {
+        let account = goa_account();
+        let ids = std::collections::HashSet::from([account.id.clone()]);
+        let mut config = vec![account.to_config(String::new(), String::new(), false)];
+        config[0].signature = Some("Local signature".into());
+
+        let paused = sync_goa_accounts(&mut config, &[], &ids);
+        assert!(paused.changed);
+        assert!(!config[0].enabled);
+        assert!(config[0].goa_mail_disabled);
+        assert_eq!(config[0].signature.as_deref(), Some("Local signature"));
+        assert!(reconcile_goa(&mut config, &ids).is_empty());
+
+        let resumed = sync_goa_accounts(
+            &mut config,
+            &[account],
+            &std::collections::HashSet::new(),
+        );
+        assert!(resumed.changed);
+        assert!(config[0].enabled);
+        assert!(!config[0].goa_mail_disabled);
+        assert_eq!(config[0].signature.as_deref(), Some("Local signature"));
+
+        // A user-disabled Vireo account stays disabled across the same GOA cycle.
+        config[0].enabled = false;
+        let paused = sync_goa_accounts(&mut config, &[], &ids);
+        assert!(paused.changed);
+        assert!(!config[0].goa_enabled_before_mail_disabled);
+        let resumed = sync_goa_accounts(
+            &mut config,
+            &[goa_account()],
+            &std::collections::HashSet::new(),
+        );
+        assert!(resumed.changed);
+        assert!(!config[0].enabled);
+    }
+
+    #[test]
+    fn goa_reconcile_removes_deleted_account() {
+        let mut config = vec![goa_account().to_config(String::new(), String::new(), false)];
+        let removed = reconcile_goa(&mut config, &std::collections::HashSet::new());
+        assert_eq!(removed, vec!["user@example.com"]);
+        assert!(config.is_empty());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,7 +22,7 @@ pub enum Protocol {
     Pop3,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct AccountConfig {
     pub name: String,
     pub email: String,
@@ -34,11 +34,27 @@ pub struct AccountConfig {
     /// Incoming server port (IMAP or POP3, per `protocol`).
     #[serde(default = "default_imap_port")]
     pub imap_port: u16,
+    /// Upgrade a plaintext IMAP connection with STARTTLS (normally port 143).
+    /// False means TLS from the first byte (normally port 993).
+    #[serde(default)]
+    pub imap_starttls: bool,
+    /// Explicit implicit-TLS mode, needed when GOA uses a custom/nonstandard
+    /// port (including an unusual implicit-TLS service on port 143).
+    #[serde(default)]
+    pub imap_implicit_tls: bool,
     /// SMTP server. If empty, derived from `imap_host` (imap.* → smtp.*).
     #[serde(default)]
     pub smtp_host: String,
     #[serde(default = "default_smtp_port")]
     pub smtp_port: u16,
+    /// Use TLS from the first byte instead of STARTTLS. Port 465 implies this
+    /// for compatibility; GOA may also specify implicit TLS on a custom port.
+    #[serde(default)]
+    pub smtp_implicit_tls: bool,
+    /// Whether the SMTP server requires authentication. GOA exposes this
+    /// explicitly; native accounts default to authenticated SMTP.
+    #[serde(default = "default_smtp_auth")]
+    pub smtp_auth: bool,
     pub username: String,
     /// Read from TOML if present (legacy/manual), but never written back —
     /// passwords belong in the keyring. Usually empty after the first run.
@@ -77,6 +93,13 @@ pub struct AccountConfig {
     /// settings/credentials trace back to the system account).
     #[serde(default)]
     pub goa_id: Option<String>,
+    /// Temporarily disabled because Mail was switched off in GOA. This preserves
+    /// local presentation settings and restores the prior enabled state later.
+    #[serde(default)]
+    pub goa_mail_disabled: bool,
+    /// Local enabled state to restore after GOA Mail is switched back on.
+    #[serde(default)]
+    pub goa_enabled_before_mail_disabled: bool,
     /// Authenticate with OAuth2 (XOAUTH2) instead of a stored password. The token
     /// comes from GOA (`goa_id`) or, for accounts added directly in Vireo, from
     /// refreshing `oauth_settings` with the keyring-stored refresh token.
@@ -92,7 +115,7 @@ pub struct AccountConfig {
 }
 
 /// OAuth2 client configuration for an account added directly in Vireo.
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
 pub struct OAuthSettings {
     pub auth_url: String,
     pub token_url: String,
@@ -115,6 +138,18 @@ impl AccountConfig {
             _ => self.email.clone(),
         }
     }
+
+    /// Port 143 is the conventional IMAP STARTTLS endpoint. Treat it as such
+    /// even for older configs written before `imap_starttls` existed; this also
+    /// prevents accidentally attempting implicit TLS against a plaintext port.
+    pub fn imap_uses_starttls(&self) -> bool {
+        !self.imap_implicit_tls
+            && (self.imap_starttls || (self.protocol == Protocol::Imap && self.imap_port == 143))
+    }
+
+    pub fn smtp_uses_implicit_tls(&self) -> bool {
+        self.smtp_implicit_tls || self.smtp_port == 465
+    }
 }
 
 fn default_imap_port() -> u16 {
@@ -123,6 +158,10 @@ fn default_imap_port() -> u16 {
 
 fn default_smtp_port() -> u16 {
     587
+}
+
+fn default_smtp_auth() -> bool {
+    true
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -134,6 +173,20 @@ struct ConfigFile {
 /// Path to the accounts config file (`~/.config/vireo/accounts.toml`).
 pub fn path() -> Option<PathBuf> {
     Some(dirs::config_dir()?.join("vireo").join("accounts.toml"))
+}
+
+/// Whether the accounts file is absent or parses successfully. Automatic
+/// discovery must not overwrite an existing malformed file that the user may
+/// still repair.
+pub fn accounts_file_is_parseable() -> bool {
+    let Some(path) = path() else {
+        return false;
+    };
+    match std::fs::read_to_string(path) {
+        Ok(text) => toml::from_str::<ConfigFile>(&text).is_ok(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+        Err(_) => false,
+    }
 }
 
 /// Returns the configured accounts, or `None` if there is no usable config
@@ -721,7 +774,38 @@ pub fn save_drawer_collapsed(collapsed: bool) {
 
 #[cfg(test)]
 mod tests {
-    use super::PrivacyFile;
+    use super::{ConfigFile, PrivacyFile};
+
+    #[test]
+    fn old_account_config_gets_secure_transport_defaults() {
+        let cfg: ConfigFile = toml::from_str(
+            r#"[[accounts]]
+name = "Example"
+email = "user@example.com"
+imap_host = "imap.example.com"
+username = "user@example.com"
+"#,
+        )
+        .unwrap();
+        let account = &cfg.accounts[0];
+        assert!(!account.imap_uses_starttls());
+        assert!(account.smtp_auth);
+    }
+
+    #[test]
+    fn old_port_143_config_is_upgraded_to_starttls() {
+        let cfg: ConfigFile = toml::from_str(
+            r#"[[accounts]]
+name = "Example"
+email = "user@example.com"
+imap_host = "imap.example.com"
+imap_port = 143
+username = "user@example.com"
+"#,
+        )
+        .unwrap();
+        assert!(cfg.accounts[0].imap_uses_starttls());
+    }
 
     #[test]
     fn notifications_default_on_when_absent() {

--- a/src/goa.rs
+++ b/src/goa.rs
@@ -7,7 +7,7 @@
 //! in Vireo's keyring on import; OAuth2 providers (Gmail, Microsoft) authenticate
 //! with a GOA-issued access token (XOAUTH2) fetched fresh at connect time.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use zbus::zvariant::{OwnedObjectPath, OwnedValue};
 
@@ -25,18 +25,20 @@ const IFACE_OAUTH2: &str = "org.gnome.OnlineAccounts.OAuth2Based";
 pub struct GoaMailAccount {
     /// GOA account id (e.g. "account_1699…").
     pub id: String,
-    /// D-Bus object path of the account.
-    pub path: String,
     pub email: String,
     pub name: String,
     pub provider: String,
     pub imap_host: String,
     pub imap_port: u16,
+    /// GOA's `ImapUseTls`: connect in plaintext, then require STARTTLS.
+    pub imap_starttls: bool,
+    pub imap_implicit_tls: bool,
     pub imap_user: String,
     pub smtp_host: String,
     pub smtp_port: u16,
+    pub smtp_implicit_tls: bool,
     pub smtp_user: String,
-    pub smtp_separate: bool,
+    pub smtp_auth: bool,
     /// Whether GOA can hand us a password (generic IMAP).
     pub password_based: bool,
     /// Whether the provider uses OAuth2 — imported accounts authenticate with a
@@ -48,7 +50,15 @@ impl GoaMailAccount {
     /// Turn a discovered GOA account into a Vireo [`AccountConfig`]. Pass the
     /// password for password-based providers, or `oauth = true` for OAuth ones
     /// (the token is fetched from GOA at connect time).
-    pub fn to_config(&self, password: String, oauth: bool) -> AccountConfig {
+    pub fn to_config(
+        &self,
+        password: String,
+        smtp_password: String,
+        oauth: bool,
+    ) -> AccountConfig {
+        // GOA stores IMAP and SMTP passwords under distinct credential ids even
+        // when their values/usernames happen to match.
+        let smtp_separate = self.smtp_auth && !oauth;
         AccountConfig {
             name: if self.name.trim().is_empty() {
                 self.email.clone()
@@ -59,17 +69,29 @@ impl GoaMailAccount {
             protocol: Protocol::Imap,
             imap_host: self.imap_host.clone(),
             imap_port: self.imap_port,
+            imap_starttls: self.imap_starttls,
+            imap_implicit_tls: self.imap_implicit_tls,
             smtp_host: self.smtp_host.clone(),
             smtp_port: self.smtp_port,
+            smtp_implicit_tls: self.smtp_implicit_tls,
+            smtp_auth: self.smtp_auth,
             username: if self.imap_user.is_empty() {
                 self.email.clone()
             } else {
                 self.imap_user.clone()
             },
             password,
-            smtp_separate: self.smtp_separate,
-            smtp_username: self.smtp_user.clone(),
-            smtp_password: String::new(),
+            smtp_separate,
+            smtp_username: if self.smtp_user.is_empty() {
+                if self.imap_user.is_empty() {
+                    self.email.clone()
+                } else {
+                    self.imap_user.clone()
+                }
+            } else {
+                self.smtp_user.clone()
+            },
+            smtp_password,
             color: None,
             emoji: None,
             signature: None,
@@ -77,6 +99,8 @@ impl GoaMailAccount {
             label: None,
             enabled: true,
             goa_id: Some(self.id.clone()),
+            goa_mail_disabled: false,
+            goa_enabled_before_mail_disabled: false,
             oauth,
             oauth_settings: None,
             oauth_refresh: String::new(),
@@ -95,22 +119,57 @@ fn get_bool(map: &HashMap<String, OwnedValue>, key: &str) -> bool {
     map.get(key).and_then(|v| bool::try_from(v).ok()).unwrap_or(false)
 }
 
+/// GOA permits a port in the host property (`mail.example.com:1143`), and Geary
+/// honours it. Split that form while also accepting bracketed IPv6 addresses.
+fn host_and_port(value: String, default_port: u16) -> (String, u16) {
+    if let Some(rest) = value.strip_prefix('[') {
+        if let Some((host, suffix)) = rest.split_once(']') {
+            let port = suffix
+                .strip_prefix(':')
+                .and_then(|p| p.parse().ok())
+                .unwrap_or(default_port);
+            return (host.to_string(), port);
+        }
+    }
+    if value.matches(':').count() == 1 {
+        if let Some((host, port)) = value.rsplit_once(':') {
+            return (host.to_string(), port.parse().unwrap_or(default_port));
+        }
+    }
+    (value, default_port)
+}
+
 type ManagedObjects =
     HashMap<OwnedObjectPath, HashMap<String, HashMap<String, OwnedValue>>>;
 
-/// List mail-capable GNOME Online Accounts. Returns an empty list if GOA isn't
-/// running or has no mail accounts — never errors into the UI.
-pub fn list_mail_accounts() -> Vec<GoaMailAccount> {
-    match try_list() {
-        Ok(v) => v,
+#[derive(Debug, Clone)]
+pub struct GoaSnapshot {
+    pub accounts: Vec<GoaMailAccount>,
+    /// Every GOA account object, including ones with Mail disabled.
+    pub account_ids: HashSet<String>,
+    /// Accounts whose Mail service is explicitly disabled in GNOME Settings.
+    pub disabled_mail_ids: HashSet<String>,
+}
+
+/// Fetch all GOA objects once and derive both the usable mail accounts and their
+/// ids. `None` means GOA is unavailable, never "there are no accounts".
+pub fn snapshot() -> Option<GoaSnapshot> {
+    match try_snapshot() {
+        Ok(snapshot) => Some(snapshot),
         Err(e) => {
             tracing::debug!("GOA discovery skipped: {e}");
-            Vec::new()
+            None
         }
     }
 }
 
-fn try_list() -> Result<Vec<GoaMailAccount>, String> {
+/// List mail-capable GNOME Online Accounts. Returns an empty list if GOA isn't
+/// running or has no mail accounts — never errors into the UI.
+pub fn list_mail_accounts() -> Vec<GoaMailAccount> {
+    snapshot().map(|snapshot| snapshot.accounts).unwrap_or_default()
+}
+
+fn try_snapshot() -> Result<GoaSnapshot, String> {
     let conn = zbus::blocking::Connection::session().map_err(|e| e.to_string())?;
     let reply = conn
         .call_method(
@@ -124,20 +183,31 @@ fn try_list() -> Result<Vec<GoaMailAccount>, String> {
     let (objects,): (ManagedObjects,) = reply.body().deserialize().map_err(|e| e.to_string())?;
 
     let mut out = Vec::new();
-    for (path, ifaces) in objects.iter() {
-        let (Some(account), Some(mail)) =
-            (ifaces.get(IFACE_ACCOUNT), ifaces.get(IFACE_MAIL))
-        else {
+    let mut account_ids = HashSet::new();
+    let mut disabled_mail_ids = HashSet::new();
+    for ifaces in objects.values() {
+        let Some(account) = ifaces.get(IFACE_ACCOUNT) else {
             continue;
         };
-        // Skip accounts whose Mail service is turned off in GNOME Settings.
+        let id = get_str(account, "Id");
+        if id.is_empty() {
+            continue;
+        }
+        account_ids.insert(id.clone());
+        let Some(mail) = ifaces.get(IFACE_MAIL) else {
+            continue;
+        };
+        // Keep the id above, but skip importing/syncing when Mail is disabled.
         if get_bool(account, "MailDisabled") {
+            disabled_mail_ids.insert(id);
             continue;
         }
 
         let imap_ssl = get_bool(mail, "ImapUseSsl");
+        let imap_tls = get_bool(mail, "ImapUseTls");
         let smtp_ssl = get_bool(mail, "SmtpUseSsl");
         let smtp_tls = get_bool(mail, "SmtpUseTls");
+        let smtp_auth = get_bool(mail, "SmtpUseAuth");
         let email = {
             let e = get_str(mail, "EmailAddress");
             if e.is_empty() {
@@ -151,10 +221,32 @@ fn try_list() -> Result<Vec<GoaMailAccount>, String> {
         }
         let imap_user = get_str(mail, "ImapUserName");
         let smtp_user = get_str(mail, "SmtpUserName");
+        let imap_host_raw = get_str(mail, "ImapHost");
+        let smtp_host_raw = get_str(mail, "SmtpHost");
+        let has_auth = ifaces.contains_key(IFACE_PASSWORD) || ifaces.contains_key(IFACE_OAUTH2);
+        // Vireo deliberately has no plaintext-mail mode. Ignore incomplete or
+        // insecure GOA mail services rather than risk sending credentials without
+        // transport encryption.
+        if !get_bool(mail, "ImapSupported")
+            || !get_bool(mail, "SmtpSupported")
+            || imap_host_raw.is_empty()
+            || smtp_host_raw.is_empty()
+            || (!imap_ssl && !imap_tls)
+            || (!smtp_ssl && !smtp_tls)
+            || !has_auth
+        {
+            continue;
+        }
+
+        let (imap_host, imap_port) =
+            host_and_port(imap_host_raw, if imap_ssl { 993 } else { 143 });
+        let (smtp_host, smtp_port) = host_and_port(
+            smtp_host_raw,
+            if smtp_ssl { 465 } else { 587 },
+        );
 
         out.push(GoaMailAccount {
-            id: get_str(account, "Id"),
-            path: path.as_str().to_string(),
+            id,
             email,
             name: {
                 let n = get_str(mail, "Name");
@@ -165,76 +257,104 @@ fn try_list() -> Result<Vec<GoaMailAccount>, String> {
                 }
             },
             provider: get_str(account, "ProviderName"),
-            imap_host: get_str(mail, "ImapHost"),
-            imap_port: if imap_ssl { 993 } else { 143 },
+            imap_host,
+            imap_port,
+            imap_starttls: !imap_ssl && imap_tls,
+            imap_implicit_tls: imap_ssl,
             imap_user: imap_user.clone(),
-            smtp_host: get_str(mail, "SmtpHost"),
-            smtp_port: if smtp_ssl {
-                465
-            } else if smtp_tls {
-                587
-            } else {
-                587
-            },
+            smtp_host,
+            smtp_port,
+            smtp_implicit_tls: smtp_ssl,
             smtp_user: smtp_user.clone(),
-            smtp_separate: !smtp_user.is_empty() && smtp_user != imap_user,
+            smtp_auth,
             password_based: ifaces.contains_key(IFACE_PASSWORD),
             oauth2: ifaces.contains_key(IFACE_OAUTH2),
         });
     }
-    Ok(out)
+    Ok(GoaSnapshot {
+        accounts: out,
+        account_ids,
+        disabled_mail_ids,
+    })
 }
 
-/// Live set of ids for accounts that currently exist in GNOME Online Accounts
-/// (any account object, mail-capable or not — so merely disabling Mail doesn't
-/// count as removal). Returns `None` when GOA / the session bus can't be reached —
-/// callers MUST treat that as "unknown", not "no accounts", or they'd wrongly
-/// prune every imported GOA account whenever GOA is momentarily unavailable.
-pub fn live_account_ids() -> Option<std::collections::HashSet<String>> {
-    let conn = zbus::blocking::Connection::session().ok()?;
-    let reply = conn
-        .call_method(
-            Some(GOA_DEST),
-            GOA_PATH,
-            Some("org.freedesktop.DBus.ObjectManager"),
-            "GetManagedObjects",
-            &(),
-        )
-        .ok()?;
-    let (objects,): (ManagedObjects,) = reply.body().deserialize().ok()?;
-    Some(
-        objects
-            .values()
-            .filter_map(|ifaces| ifaces.get(IFACE_ACCOUNT))
-            .map(|account| get_str(account, "Id"))
-            .filter(|id| !id.is_empty())
-            .collect(),
-    )
-}
-
-/// Watch GNOME Online Accounts for account/interface removals, invoking
-/// `on_change` on each. Runs on a dedicated thread; silently no-ops if GOA or the
-/// session bus is unavailable. Lets Vireo prune accounts removed in GNOME Settings
-/// without a restart.
-pub fn watch_removals<F: Fn() + Send + 'static>(on_change: F) {
+/// Watch GNOME Online Accounts for additions, removals and property changes so
+/// newly enabled mail accounts and server-setting edits appear without restart.
+pub fn watch_changes<F: Fn() + Send + 'static>(on_change: F) {
+    // ObjectManager and PropertiesChanged commonly arrive in bursts for one
+    // Settings edit. Coalesce them before doing a single background snapshot.
+    let (tx, rx) = std::sync::mpsc::channel::<()>();
     let _ = std::thread::Builder::new()
-        .name("goa-watch".into())
+        .name("goa-change-dispatch".into())
         .spawn(move || {
-            if let Err(e) = watch_loop(&on_change) {
-                tracing::debug!("GOA watch stopped: {e}");
+            while rx.recv().is_ok() {
+                while rx.recv_timeout(std::time::Duration::from_millis(300)).is_ok() {}
+                on_change();
+            }
+        });
+
+    for added in [true, false] {
+        let changed = tx.clone();
+        let name = if added { "goa-added-watch" } else { "goa-removed-watch" };
+        let _ = std::thread::Builder::new()
+            .name(name.into())
+            .spawn(move || {
+                let callback = || {
+                    let _ = changed.send(());
+                };
+                if let Err(e) = watch_object_manager(&callback, added) {
+                    tracing::debug!("GOA watch stopped: {e}");
+                }
+            });
+    }
+    let changed = tx;
+    let _ = std::thread::Builder::new()
+        .name("goa-properties-watch".into())
+        .spawn(move || {
+            let callback = || {
+                let _ = changed.send(());
+            };
+            if let Err(e) = watch_properties(&callback) {
+                tracing::debug!("GOA properties watch stopped: {e}");
             }
         });
 }
 
-fn watch_loop<F: Fn()>(on_change: &F) -> Result<(), Box<dyn std::error::Error>> {
+fn watch_object_manager<F: Fn()>(
+    on_change: &F,
+    added: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
     let conn = zbus::blocking::Connection::session()?;
     let om = zbus::blocking::fdo::ObjectManagerProxy::builder(&conn)
         .destination(GOA_DEST)?
         .path(GOA_PATH)?
         .build()?;
-    // Blocks until GOA emits an InterfacesRemoved signal; ends if the bus closes.
-    let mut removed = om.receive_interfaces_removed()?;
-    for _ in removed.by_ref() {
+    if added {
+        let mut signals = om.receive_interfaces_added()?;
+        for _ in signals.by_ref() {
+            on_change();
+        }
+    } else {
+        let mut signals = om.receive_interfaces_removed()?;
+        for _ in signals.by_ref() {
+            on_change();
+        }
+    }
+    Ok(())
+}
+
+fn watch_properties<F: Fn()>(on_change: &F) -> Result<(), Box<dyn std::error::Error>> {
+    let conn = zbus::blocking::Connection::session()?;
+    let rule = zbus::MatchRule::builder()
+        .msg_type(zbus::message::Type::Signal)
+        .sender(GOA_DEST)?
+        .interface("org.freedesktop.DBus.Properties")?
+        .member("PropertiesChanged")?
+        .path_namespace("/org/gnome/OnlineAccounts/Accounts")?
+        .build();
+    let signals = zbus::blocking::MessageIterator::for_match_rule(rule, &conn, Some(32))?;
+    for signal in signals {
+        signal?;
         on_change();
     }
     Ok(())
@@ -244,7 +364,10 @@ fn watch_loop<F: Fn()>(on_change: &F) -> Result<(), Box<dyn std::error::Error>> 
 /// token as needed, so this always returns a currently-valid token. Blocking.
 pub fn oauth_token(goa_id: &str) -> Option<String> {
     let conn = zbus::blocking::Connection::session().ok()?;
-    let path = format!("/org/gnome/OnlineAccounts/Accounts/{goa_id}");
+    let path = account_path(goa_id);
+    // Follow GOA's documented flow (and Geary's implementation): ensure/renew
+    // credentials before asking for the current token.
+    let _ = ensure_credentials_with(&conn, &path);
     let reply = conn
         .call_method(
             Some(GOA_DEST),
@@ -263,24 +386,127 @@ pub fn oauth_token(goa_id: &str) -> Option<String> {
     }
 }
 
-/// Fetch a GOA account's mail password (password-based providers only).
-pub fn fetch_password(path: &str, goa_id: &str) -> Option<String> {
-    let conn = zbus::blocking::Connection::session().ok()?;
-    // GOA's GetPassword takes an id argument; the account id is the usual key.
+fn account_path(goa_id: &str) -> String {
+    format!("/org/gnome/OnlineAccounts/Accounts/{goa_id}")
+}
+
+/// Ask GOA to validate/renew credentials. A second attempt mirrors Geary's
+/// retry after an authorization failure. Password lookup is still attempted if
+/// this fails: GOA may have a usable cached secret while the provider is offline.
+fn ensure_credentials_with(conn: &zbus::blocking::Connection, path: &str) -> bool {
+    let call = || {
+        conn.call_method(
+            Some(GOA_DEST),
+            path,
+            Some(IFACE_ACCOUNT),
+            "EnsureCredentials",
+            &(),
+        )
+    };
+    call().or_else(|_| call()).is_ok()
+}
+
+fn fetch_password_with(
+    conn: &zbus::blocking::Connection,
+    path: &str,
+    credential_id: &str,
+) -> Option<String> {
     let reply = conn
         .call_method(
             Some(GOA_DEST),
             path,
             Some(IFACE_PASSWORD),
             "GetPassword",
-            &(goa_id,),
+            &(credential_id,),
         )
         .ok()?;
     let (password,): (String,) = reply.body().deserialize().ok()?;
-    if password.is_empty() {
-        None
-    } else {
-        Some(password)
+    (!password.is_empty()).then_some(password)
+}
+
+/// Fetch both password-based mail credentials directly from GOA. They stay in
+/// worker memory and are not copied into Vireo's own keyring.
+pub fn mail_passwords(goa_id: &str) -> (Option<String>, Option<String>) {
+    let conn = match zbus::blocking::Connection::session() {
+        Ok(conn) => conn,
+        Err(_) => return (None, None),
+    };
+    let path = account_path(goa_id);
+    let _ = ensure_credentials_with(&conn, &path);
+    (
+        fetch_password_with(&conn, &path, "imap-password"),
+        fetch_password_with(&conn, &path, "smtp-password"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{host_and_port, GoaMailAccount};
+
+    fn mail_account() -> GoaMailAccount {
+        GoaMailAccount {
+            id: "account_1".into(),
+            email: "user@example.com".into(),
+            name: "Example User".into(),
+            provider: "IMAP and SMTP".into(),
+            imap_host: "imap.example.com".into(),
+            imap_port: 143,
+            imap_starttls: true,
+            imap_implicit_tls: false,
+            imap_user: "incoming-user".into(),
+            smtp_host: "smtp.example.com".into(),
+            smtp_port: 587,
+            smtp_implicit_tls: false,
+            smtp_user: "outgoing-user".into(),
+            smtp_auth: true,
+            password_based: true,
+            oauth2: false,
+        }
+    }
+
+    #[test]
+    fn goa_host_may_include_a_custom_port() {
+        assert_eq!(
+            host_and_port("mail.example.com:1143".into(), 143),
+            ("mail.example.com".into(), 1143)
+        );
+        assert_eq!(
+            host_and_port("[2001:db8::1]:1993".into(), 993),
+            ("2001:db8::1".into(), 1993)
+        );
+        assert_eq!(
+            host_and_port("mail.example.com".into(), 993),
+            ("mail.example.com".into(), 993)
+        );
+    }
+
+    #[test]
+    fn password_account_keeps_goa_transport_and_separate_credentials() {
+        let config = mail_account().to_config("imap-secret".into(), "smtp-secret".into(), false);
+        assert!(config.imap_starttls);
+        assert!(config.smtp_auth);
+        assert!(config.smtp_separate);
+        assert_eq!(config.username, "incoming-user");
+        assert_eq!(config.smtp_username, "outgoing-user");
+        assert_eq!(config.password, "imap-secret");
+        assert_eq!(config.smtp_password, "smtp-secret");
+    }
+
+    #[test]
+    fn oauth_account_does_not_enable_password_credentials() {
+        let config = mail_account().to_config(String::new(), String::new(), true);
+        assert!(config.oauth);
+        assert!(!config.smtp_separate);
+        assert_eq!(config.goa_id.as_deref(), Some("account_1"));
+    }
+
+    #[test]
+    fn custom_smtp_port_preserves_implicit_tls() {
+        let mut account = mail_account();
+        account.smtp_port = 8465;
+        account.smtp_implicit_tls = true;
+        let config = account.to_config(String::new(), String::new(), true);
+        assert!(config.smtp_uses_implicit_tls());
     }
 }
 

--- a/src/ui/accounts.rs
+++ b/src/ui/accounts.rs
@@ -598,6 +598,7 @@ impl Component for AccountsWindow {
                 self.pending_oauth_refresh = None;
                 clear_editor(widgets);
                 self.apply_provider(widgets);
+                set_connection_editable(widgets, true);
                 self.sig_editor.set_html("");
                 widgets.color_btn.set_rgba(&parse_color(DEFAULT_COLOR));
                 widgets.emoji_btn.set_label("Add");
@@ -626,9 +627,18 @@ impl Component for AccountsWindow {
                 // GOA accounts: no "Remove" (it lives in the system) — offer an
                 // enable/disable toggle and a shortcut to Online Accounts instead.
                 let is_goa = acc.goa_id.is_some();
+                set_connection_editable(widgets, !is_goa);
                 widgets.remove_group.set_visible(!is_goa);
                 widgets.goa_manage_group.set_visible(is_goa);
                 widgets.goa_enabled_row.set_active(acc.enabled);
+                widgets
+                    .goa_enabled_row
+                    .set_sensitive(!acc.goa_mail_disabled);
+                widgets.goa_enabled_row.set_subtitle(if acc.goa_mail_disabled {
+                    "Mail is disabled for this account in GNOME Settings"
+                } else {
+                    ""
+                });
                 widgets.nav.push_by_tag("editor");
             }
 
@@ -656,6 +666,9 @@ impl Component for AccountsWindow {
 
             AccountsInput::ToggleEnabled { index, enabled } => {
                 if let Some(acc) = self.accounts.get_mut(index) {
+                    if acc.goa_mail_disabled {
+                        return;
+                    }
                     if acc.enabled != enabled {
                         acc.enabled = enabled;
                         let email = acc.email.clone();
@@ -667,6 +680,9 @@ impl Component for AccountsWindow {
             AccountsInput::ToggleCurrentEnabled(enabled) => {
                 if let Some(i) = self.editing {
                     if let Some(acc) = self.accounts.get_mut(i) {
+                        if acc.goa_mail_disabled {
+                            return;
+                        }
                         if acc.enabled != enabled {
                             acc.enabled = enabled;
                             let email = acc.email.clone();
@@ -679,14 +695,9 @@ impl Component for AccountsWindow {
 
             AccountsInput::ImportGoa(index) => {
                 if let Some(g) = self.goa.get(index).cloned() {
-                    // Password-based providers: pull the password now. OAuth
-                    // providers: authenticate with a GOA token at connect time.
-                    let (password, oauth) = if g.password_based {
-                        (crate::goa::fetch_password(&g.path, &g.id).unwrap_or_default(), false)
-                    } else {
-                        (String::new(), true)
-                    };
-                    let account = g.to_config(password, oauth);
+                    // GOA remains authoritative for secrets even on this legacy
+                    // manual path; workers fetch them directly when connecting.
+                    let account = g.to_config(String::new(), String::new(), g.oauth2);
                     self.goa.remove(index);
                     self.accounts.push(account.clone());
                     self.rebuild_account_list(&widgets.accounts_list, &sender);
@@ -707,7 +718,15 @@ impl Component for AccountsWindow {
             }
 
             AccountsInput::TestConnection => {
-                let account = read_account(widgets, self.emoji.clone());
+                let mut account = read_account(widgets, self.emoji.clone());
+                if let Some(orig) = self.editing.and_then(|i| self.accounts.get(i)) {
+                    preserve_hidden_transport(&mut account, orig);
+                    account.goa_id = orig.goa_id.clone();
+                    if orig.goa_id.is_some() {
+                        account.oauth = orig.oauth;
+                        account.oauth_settings = orig.oauth_settings.clone();
+                    }
+                }
                 widgets.test_btn.set_sensitive(false);
                 widgets.test_result.set_visible(true);
                 widgets.test_result.set_css_classes(&["dim-label"]);
@@ -783,8 +802,12 @@ impl Component for AccountsWindow {
                 // (GOA-driven) OAuth mechanism regardless of the Authentication combo.
                 let editing_orig = self.editing.and_then(|i| self.accounts.get(i)).cloned();
                 if let Some(orig) = &editing_orig {
+                    preserve_hidden_transport(&mut account, orig);
                     account.enabled = orig.enabled;
                     account.goa_id = orig.goa_id.clone();
+                    account.goa_mail_disabled = orig.goa_mail_disabled;
+                    account.goa_enabled_before_mail_disabled =
+                        orig.goa_enabled_before_mail_disabled;
                     if orig.goa_id.is_some() {
                         account.oauth = orig.oauth;
                         account.oauth_settings = orig.oauth_settings.clone();
@@ -830,13 +853,17 @@ impl Component for AccountsWindow {
                 } else {
                     true
                 };
-                let password_ok = account.oauth || !account.password.is_empty();
+                // GOA-managed secrets are intentionally absent from this form:
+                // workers fetch them directly from GOA when they connect.
+                let goa_managed = account.goa_id.is_some();
+                let password_ok = account.oauth || goa_managed || !account.password.is_empty();
                 if account.imap_host.is_empty()
                     || account.username.is_empty()
                     || !password_ok
                     || !oauth_ready
                     || (account.smtp_separate
-                        && (account.smtp_username.is_empty() || account.smtp_password.is_empty()))
+                        && (account.smtp_username.is_empty()
+                            || (!goa_managed && account.smtp_password.is_empty())))
                 {
                     widgets.host_row.add_css_class("error");
                     return;
@@ -1002,8 +1029,13 @@ impl AccountsWindow {
             // sync or appear in the sidebar.
             let toggle = gtk::Switch::new();
             toggle.set_valign(gtk::Align::Center);
-            toggle.set_tooltip_text(Some("Enable this account"));
+            toggle.set_tooltip_text(Some(if acc.goa_mail_disabled {
+                "Mail is disabled for this account in GNOME Settings"
+            } else {
+                "Enable this account"
+            }));
             toggle.set_active(acc.enabled);
+            toggle.set_sensitive(!acc.goa_mail_disabled);
             let ti = sender.input_sender().clone();
             let tpos = pos;
             toggle.connect_state_set(move |_, state| {
@@ -1247,6 +1279,35 @@ fn display_name(acc: &AccountConfig) -> String {
     }
 }
 
+fn preserve_hidden_transport(account: &mut AccountConfig, original: &AccountConfig) {
+    // The editor exposes ports but not the transport/authentication switches.
+    // Keep custom modes when the corresponding port was not changed.
+    if account.imap_port == original.imap_port {
+        account.imap_starttls = original.imap_starttls;
+        account.imap_implicit_tls = original.imap_implicit_tls;
+    }
+    if account.smtp_port == original.smtp_port {
+        account.smtp_implicit_tls = original.smtp_implicit_tls;
+    }
+    account.smtp_auth = original.smtp_auth;
+}
+
+fn set_connection_editable(widgets: &AccountsWindowWidgets, editable: bool) {
+    widgets.provider_row.set_sensitive(editable);
+    widgets.name_row.set_sensitive(true); // local From/display name
+    widgets.email_row.set_sensitive(editable);
+    widgets.protocol_row.set_sensitive(editable);
+    widgets.host_row.set_sensitive(editable);
+    widgets.port_row.set_sensitive(editable);
+    widgets.smtp_row.set_sensitive(editable);
+    widgets.smtp_port_row.set_sensitive(editable);
+    widgets.user_row.set_sensitive(editable);
+    widgets.pass_row.set_sensitive(editable);
+    widgets.smtp_separate_row.set_sensitive(editable);
+    widgets.smtp_user_row.set_sensitive(editable);
+    widgets.smtp_pass_row.set_sensitive(editable);
+}
+
 /// Build an `AccountConfig` from the current editor form values.
 fn read_account(widgets: &AccountsWindowWidgets, emoji: Option<String>) -> AccountConfig {
     let protocol = if widgets.protocol_row.selected() == 1 {
@@ -1261,8 +1322,16 @@ fn read_account(widgets: &AccountsWindowWidgets, emoji: Option<String>) -> Accou
         protocol,
         imap_host: trimmed(&widgets.host_row),
         imap_port: trimmed(&widgets.port_row).parse().unwrap_or(default_port),
+        // The native editor follows the conventional ports: 143 is STARTTLS,
+        // while 993 is implicit TLS. GOA supplies this flag explicitly.
+        imap_starttls: protocol == Protocol::Imap
+            && trimmed(&widgets.port_row).parse::<u16>().unwrap_or(default_port) == 143,
+        imap_implicit_tls: protocol == Protocol::Imap
+            && trimmed(&widgets.port_row).parse::<u16>().unwrap_or(default_port) == 993,
         smtp_host: trimmed(&widgets.smtp_row),
         smtp_port: trimmed(&widgets.smtp_port_row).parse().unwrap_or(587),
+        smtp_implicit_tls: trimmed(&widgets.smtp_port_row).parse::<u16>().unwrap_or(587) == 465,
+        smtp_auth: true,
         username: trimmed(&widgets.user_row),
         password: widgets.pass_row.text().to_string(),
         smtp_separate: widgets.smtp_separate_row.is_active(),
@@ -1286,6 +1355,8 @@ fn read_account(widgets: &AccountsWindowWidgets, emoji: Option<String>) -> Accou
         // Defaults for a new account; preserved from the original when editing.
         enabled: true,
         goa_id: None,
+        goa_mail_disabled: false,
+        goa_enabled_before_mail_disabled: false,
         oauth: false,
         oauth_settings: None,
         oauth_refresh: String::new(),

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -251,29 +251,53 @@ async fn run(
 // IMAP path
 // ---------------------------------------------------------------------------
 
+/// Resolve account credentials without copying GOA-owned secrets into Vireo's
+/// keyring. GOA remains the source of truth; passwords live only in worker memory.
+async fn resolve_credentials(account: &mut AccountConfig, persist_supplied: bool) {
+    let from_goa = account.goa_id.is_some() && !account.oauth;
+    if let Some(goa_id) = account.goa_id.clone().filter(|_| !account.oauth) {
+        if let Ok((incoming, smtp)) =
+            tokio::task::spawn_blocking(move || crate::goa::mail_passwords(&goa_id)).await
+        {
+            if let Some(password) = incoming.as_ref() {
+                account.password = password.clone();
+            }
+            if let Some(password) = smtp.or(incoming) {
+                // Some GOA backends expose one shared mail password even though
+                // the standard credential ids are separate.
+                account.smtp_password = password;
+            }
+        }
+    }
+
+    if account.password.is_empty() {
+        if let Some(pw) = crate::config::load_password(&account.email) {
+            account.password = pw;
+        }
+    } else if !from_goa && persist_supplied {
+        let _ = crate::config::store_password(&account.email, &account.password);
+        crate::config::strip_passwords_on_disk();
+    }
+    if account.smtp_separate && account.smtp_password.is_empty() {
+        if let Some(pw) = crate::config::load_smtp_password(&account.email) {
+            account.smtp_password = pw;
+        }
+    } else if account.smtp_separate
+        && !account.smtp_password.is_empty()
+        && !from_goa
+        && persist_supplied
+    {
+        let _ = crate::config::store_smtp_password(&account.email, &account.smtp_password);
+    }
+}
+
 async fn run_imap(
     account_id: u32,
     mut account: AccountConfig,
     mut rx: mpsc::UnboundedReceiver<MailRequest>,
     emit: impl Fn(WorkerEvent),
 ) {
-    // Resolve the password off the main thread: migrate a legacy plaintext
-    // password into the keyring (and strip it from disk), otherwise load it from
-    // the keyring.
-    if account.password.is_empty() {
-        if let Some(pw) = crate::config::load_password(&account.email) {
-            account.password = pw;
-        }
-    } else {
-        let _ = crate::config::store_password(&account.email, &account.password);
-        crate::config::strip_passwords_on_disk();
-    }
-    // Resolve the separate SMTP password from the keyring when in use.
-    if account.smtp_separate && account.smtp_password.is_empty() {
-        if let Some(pw) = crate::config::load_smtp_password(&account.email) {
-            account.smtp_password = pw;
-        }
-    }
+    resolve_credentials(&mut account, true).await;
 
     let cache = Cache::open()
         .map_err(|e| tracing::warn!("cache unavailable: {e}"))
@@ -1568,27 +1592,32 @@ fn build_email(account: &AccountConfig, msg: &OutgoingMessage) -> Result<LettreM
 }
 
 async fn send_smtp(account: &AccountConfig, msg: &OutgoingMessage) -> Result<Vec<u8>, SmtpError> {
+    // GOA credentials can change while an IMAP session remains connected.
+    // Resolve them again immediately before SMTP authentication.
+    let mut resolved = account.clone();
+    resolve_credentials(&mut resolved, false).await;
+    let account = &resolved;
     let email = build_email(account, msg)?;
     let raw = email.formatted();
 
     let host = smtp_host(account);
     // Port 465 is implicit TLS; everything else (587, etc.) uses STARTTLS.
-    let transport_builder = if account.smtp_port == 465 {
+    let transport_builder = if account.smtp_uses_implicit_tls() {
         AsyncSmtpTransport::<Tokio1Executor>::relay(&host)?
     } else {
         AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&host)?
     };
     let mut builder = transport_builder.port(account.smtp_port);
-    if account.oauth {
+    if account.smtp_auth && account.oauth {
         // XOAUTH2: the "password" is a fresh OAuth token from GOA.
         let token = fetch_oauth_token(account).await.ok_or_else(|| -> SmtpError {
             "could not get an OAuth token from GNOME Online Accounts".into()
         })?;
-        let user = oauth_user(account);
+        let user = smtp_oauth_user(account);
         builder = builder
             .credentials(Credentials::new(user, token))
             .authentication(vec![lettre::transport::smtp::authentication::Mechanism::Xoauth2]);
-    } else {
+    } else if account.smtp_auth {
         // Use the separate SMTP credentials when configured, else the IMAP ones.
         let creds = if account.smtp_separate {
             Credentials::new(account.smtp_username.clone(), account.smtp_password.clone())
@@ -1609,6 +1638,16 @@ fn oauth_user(account: &AccountConfig) -> String {
         account.email.clone()
     } else {
         account.username.clone()
+    }
+}
+
+/// SMTP may use a different SASL identity even though both services share the
+/// same GOA OAuth token.
+fn smtp_oauth_user(account: &AccountConfig) -> String {
+    if account.smtp_username.trim().is_empty() {
+        oauth_user(account)
+    } else {
+        account.smtp_username.clone()
     }
 }
 
@@ -1874,15 +1913,52 @@ async fn mark_spam(
     move_or_create(session, path, uid, dest).await
 }
 
+const IMAP_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 async fn connect(account: &AccountConfig) -> Result<ImapSession, Box<dyn std::error::Error>> {
+    // Every retry path eventually comes through here. Refresh GOA/keyring
+    // credentials first so reconnect helpers never reuse a stale worker copy.
+    let mut resolved = account.clone();
+    resolve_credentials(&mut resolved, false).await;
+    match tokio::time::timeout(IMAP_CONNECT_TIMEOUT, connect_inner(&resolved)).await {
+        Ok(result) => result,
+        Err(_) => Err(format!(
+            "IMAP connection to {}:{} timed out",
+            account.imap_host, account.imap_port
+        )
+        .into()),
+    }
+}
+
+async fn connect_inner(account: &AccountConfig) -> Result<ImapSession, Box<dyn std::error::Error>> {
     let tcp = TcpStream::connect((account.imap_host.as_str(), account.imap_port)).await?;
     let tls = async_native_tls::TlsConnector::new();
-    let stream = tls.connect(account.imap_host.as_str(), tcp).await?;
-    let mut client = async_imap::Client::new(stream);
-    // Consume the server greeting before issuing commands. LOGIN tolerates an
-    // unread greeting, but the AUTHENTICATE handshake reads it as the command
-    // reply and deadlocks — so read it explicitly here.
-    let _ = client.read_response().await;
+    let client = if account.imap_uses_starttls() {
+        // GOA distinguishes implicit TLS (`ImapUseSsl`) from STARTTLS
+        // (`ImapUseTls`). Require STARTTLS before sending any credentials.
+        let mut plain = async_imap::Client::new(tcp);
+        plain
+            .read_response()
+            .await
+            .ok_or("IMAP server closed before its greeting")??;
+        // On async-imap 0.10's unauthenticated Client this is the Connection
+        // method; its second argument is the optional unsolicited-response sink.
+        plain.run_command_and_check_ok("STARTTLS", None).await?;
+        let stream = tls
+            .connect(account.imap_host.as_str(), plain.into_inner())
+            .await?;
+        async_imap::Client::new(stream)
+    } else {
+        let stream = tls.connect(account.imap_host.as_str(), tcp).await?;
+        let mut client = async_imap::Client::new(stream);
+        // Consume the greeting before AUTHENTICATE; LOGIN happens to tolerate an
+        // unread greeting, while the OAuth exchange does not.
+        client
+            .read_response()
+            .await
+            .ok_or("IMAP server closed before its greeting")??;
+        client
+    };
     let session = if account.oauth {
         // XOAUTH2 with a fresh access token (from GOA or a native refresh token).
         let token = fetch_oauth_token(account)
@@ -1933,9 +2009,12 @@ async fn test_pop3(account: &AccountConfig) -> Result<(), String> {
 /// Blocking wrapper around [`test_connection`] that spins up its own Tokio
 /// runtime — call it from `spawn_blocking` so the IMAP/SMTP sockets have an I/O
 /// reactor regardless of the caller's runtime.
-pub fn test_connection_blocking(account: AccountConfig) -> ConnTest {
+pub fn test_connection_blocking(mut account: AccountConfig) -> ConnTest {
     match tokio::runtime::Builder::new_current_thread().enable_all().build() {
-        Ok(rt) => rt.block_on(test_connection(&account)),
+        Ok(rt) => rt.block_on(async {
+            resolve_credentials(&mut account, false).await;
+            test_connection(&account).await
+        }),
         Err(e) => ConnTest {
             incoming: Err(e.to_string()),
             smtp: Err(e.to_string()),
@@ -1959,19 +2038,34 @@ async fn test_smtp(account: &AccountConfig) -> Result<(), String> {
     use lettre::transport::smtp::extension::ClientId;
 
     let host = smtp_host(account);
-    let (user, pass) = if account.smtp_separate {
-        (account.smtp_username.clone(), account.smtp_password.clone())
+    let (creds, mechanisms) = if account.oauth {
+        let token = fetch_oauth_token(account)
+            .await
+            .ok_or_else(|| "could not get an OAuth token from GNOME Online Accounts".to_string())?;
+        (
+            Credentials::new(smtp_oauth_user(account), token),
+            vec![Mechanism::Xoauth2],
+        )
     } else {
-        (account.username.clone(), account.password.clone())
+        let (user, pass) = if account.smtp_separate {
+            (account.smtp_username.clone(), account.smtp_password.clone())
+        } else {
+            (account.username.clone(), account.password.clone())
+        };
+        (
+            Credentials::new(user, pass),
+            vec![Mechanism::Plain, Mechanism::Login],
+        )
     };
-    let creds = Credentials::new(user, pass);
     let hello = ClientId::default();
     let tls = TlsParameters::new(host.clone()).map_err(|e| e.to_string())?;
-    let addr = format!("{host}:{}", account.smtp_port);
+    // A tuple keeps IPv6 literals unambiguous; formatting `host:port` would
+    // require manually restoring brackets stripped while parsing GOA settings.
+    let addr = (host.as_str(), account.smtp_port);
     let timeout = Some(std::time::Duration::from_secs(20));
 
     // Port 465 is implicit TLS; everything else uses STARTTLS.
-    let mut conn = if account.smtp_port == 465 {
+    let mut conn = if account.smtp_uses_implicit_tls() {
         AsyncSmtpConnection::connect_tokio1(addr, timeout, &hello, Some(tls), None)
             .await
             .map_err(|e| e.to_string())?
@@ -1982,11 +2076,14 @@ async fn test_smtp(account: &AccountConfig) -> Result<(), String> {
         conn.starttls(tls, &hello).await.map_err(|e| e.to_string())?;
         conn
     };
-    let result = conn
-        .auth(&[Mechanism::Plain, Mechanism::Login], &creds)
-        .await
-        .map(|_| ())
-        .map_err(|e| e.to_string());
+    let result = if account.smtp_auth {
+        conn.auth(&mechanisms, &creds)
+            .await
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    } else {
+        Ok(())
+    };
     let _ = conn.quit().await;
     result
 }
@@ -3016,20 +3113,7 @@ async fn run_pop3(
     mut rx: mpsc::UnboundedReceiver<MailRequest>,
     emit: impl Fn(WorkerEvent),
 ) {
-    // Resolve credentials from the keyring (same as the IMAP path).
-    if account.password.is_empty() {
-        if let Some(pw) = crate::config::load_password(&account.email) {
-            account.password = pw;
-        }
-    } else {
-        let _ = crate::config::store_password(&account.email, &account.password);
-        crate::config::strip_passwords_on_disk();
-    }
-    if account.smtp_separate && account.smtp_password.is_empty() {
-        if let Some(pw) = crate::config::load_smtp_password(&account.email) {
-            account.smtp_password = pw;
-        }
-    }
+    resolve_credentials(&mut account, true).await;
 
     let cache = Cache::open().map_err(|e| tracing::warn!("cache unavailable: {e}")).ok();
     const INBOX: &str = "INBOX";


### PR DESCRIPTION
## Summary

- automatically import mail-enabled GNOME Online Accounts and synchronize additions, removals, Mail enablement and property changes
- keep GOA authoritative for passwords/OAuth tokens; secrets remain in worker memory and are refreshed before reconnects and SMTP sends
- support separate IMAP/SMTP credentials, OAuth/XOAUTH2, SMTP auth flags, custom ports, IPv4/IPv6 and explicit implicit-TLS/STARTTLS modes
- require encrypted transports and stabilize IMAP port 143 with fail-closed STARTTLS plus a 30-second connection timeout
- preserve local sender name, signature, label, colour, emoji, enabled state and sidebar state while refreshing GOA-owned settings
- pause rather than delete an account when Mail is disabled in GNOME Settings, then restore it without losing local settings
- debounce GOA D-Bus changes and fetch snapshots off the GTK thread
- refuse to overwrite a malformed existing accounts file

## Testing

- `cargo check --locked`
- `cargo test --locked` — 53 passed
- `cargo clippy --all-targets --locked` — passes; pre-existing style warnings remain
- combined GOA + contact-avatar build: 57 passed
- release build tested with live GOA accounts on IMAP 143 STARTTLS and IMAP 993 implicit TLS simultaneously
- `air.basealt.ru:143` negotiated TLS 1.3 with certificate verification OK
- confirmed `accounts.toml` contains no password/token fields
- multiple independent Codex and Claude review rounds completed and findings addressed
