### PR TITLE
Load sender avatars from GNOME Contacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2957,6 +2957,7 @@ version = "1.7.0"
 dependencies = [
  "async-imap",
  "async-native-tls",
+ "base64",
  "chrono",
  "dirs",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ dirs = "5"
 md5 = "0.7"
 ureq = { version = "2", features = ["json"] }
 serde_json = "1"
+base64 = "0.22"
 
 # GNOME Contacts integration via Evolution Data Server (D-Bus)
 zbus = "4"

--- a/src/app.rs
+++ b/src/app.rs
@@ -261,6 +261,7 @@ pub enum AppMsg {
     RemoveBlacklist(String),
     MarkSpam,
     SetGravatar(bool),
+    ContactPhotosChanged,
     SetThreading(bool),
     SetThreadsExpanded(bool),
     SetFetchInterval(u64),
@@ -826,6 +827,12 @@ impl SimpleComponent for AppModel {
             gallery_by_account: HashMap::new(),
         };
         model.spawn_workers(&sender);
+        crate::contacts::watch_photo_changes({
+            let input = sender.input_sender().clone();
+            move || {
+                let _ = input.send(AppMsg::ContactPhotosChanged);
+            }
+        });
         // Watch GNOME Online Accounts so an account removed there disappears from
         // Vireo live (no restart needed); reconciliation happens on GoaChanged.
         crate::goa::watch_removals({
@@ -1608,6 +1615,11 @@ impl SimpleComponent for AppModel {
                     let current = self.current.clone();
                     self.show_message(current, false);
                 }
+            }
+
+            AppMsg::ContactPhotosChanged => {
+                self.message_list.emit(MessageListInput::ContactPhotosChanged);
+                self.message_view.emit(MessageViewInput::ContactPhotosChanged);
             }
 
             AppMsg::SetFetchInterval(secs) => {

--- a/src/avatar.rs
+++ b/src/avatar.rs
@@ -1,57 +1,448 @@
-//! Gravatar support (opt-in). Builds the Gravatar URL from an email's MD5,
-//! fetches the image over HTTPS (blocking — call from a relm4 command, off the
-//! main thread), and caches decoded textures on the main thread so rows and the
-//! reader don't refetch the same sender.
+//! Sender-avatar loading and caching. Local GNOME Contacts / CardDAV photos are
+//! preferred. Gravatar is an optional fallback and is only queried when enabled.
 //!
-//! Privacy note: enabling Gravatar sends a hash of each sender's email to a
-//! third party (Gravatar/Automattic). It is therefore off by default and gated
-//! behind a Preferences toggle.
+//! Privacy note: local contact photos are read from Evolution Data Server's
+//! on-disk cache and make no network request. Gravatar sends a hash of the
+//! sender's email to Automattic, so it remains off by default.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
+
+use gtk::prelude::Cast;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AvatarSource {
+    Contact,
+    Gravatar,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FetchMode {
+    ContactOnly,
+    ContactThenGravatar,
+    GravatarOnly,
+}
+
+#[derive(Debug, Clone)]
+struct DecodedImage {
+    pixels: Arc<[u8]>,
+    width: i32,
+    height: i32,
+}
+
+#[derive(Debug)]
+pub struct FetchedAvatar {
+    image: DecodedImage,
+    pub source: AvatarSource,
+}
+
+#[derive(Debug)]
+pub enum FetchOutcome {
+    Found(FetchedAvatar),
+    Missing,
+    /// A transient Gravatar failure; retry on a later render.
+    Retry,
+}
+
+pub enum CacheLookup {
+    Texture(gtk::gdk::Texture),
+    Missing,
+    Fetch { generation: u64, mode: FetchMode },
+}
+
+struct ContactCache {
+    generation: u64,
+    texture: Option<gtk::gdk::Texture>,
+}
 
 thread_local! {
-    static CACHE: RefCell<HashMap<String, gtk::gdk::Texture>> = RefCell::new(HashMap::new());
+    // Contact state is generation-bound; Gravatar state survives EDS changes so
+    // a CardDAV sync never causes unnecessary third-party requests.
+    static CONTACT_CACHE: RefCell<HashMap<String, ContactCache>> = RefCell::new(HashMap::new());
+    static GRAVATAR_CACHE: RefCell<HashMap<String, Option<gtk::gdk::Texture>>> =
+        RefCell::new(HashMap::new());
 }
 
 fn key(email: &str) -> String {
     email.trim().to_lowercase()
 }
 
-/// A previously decoded texture for this sender, if cached (main thread only).
-pub fn cached(email: &str) -> Option<gtk::gdk::Texture> {
-    CACHE.with(|c| c.borrow().get(&key(email)).cloned())
-}
-
-fn store(email: &str, tex: gtk::gdk::Texture) {
-    CACHE.with(|c| {
-        c.borrow_mut().insert(key(email), tex);
+/// Consult the main-thread texture/miss caches without doing I/O.
+pub fn lookup(email: &str, allow_gravatar: bool) -> CacheLookup {
+    let key = key(email);
+    let generation = crate::contacts::photo_generation();
+    if !crate::contacts::photos_ready() {
+        // Never disclose a sender hash to Gravatar before the local EDS index
+        // has had a chance to answer.
+        return CacheLookup::Fetch {
+            generation,
+            mode: FetchMode::ContactOnly,
+        };
+    }
+    let contact = CONTACT_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if cache
+            .get(&key)
+            .is_some_and(|cached| cached.generation != generation)
+        {
+            cache.remove(&key);
+        }
+        cache.get(&key).map(|cached| cached.texture.clone())
     });
+
+    if let Some(Some(texture)) = contact {
+        return CacheLookup::Texture(texture);
+    }
+    let gravatar = GRAVATAR_CACHE.with(|cache| cache.borrow().get(&key).cloned());
+    if contact.is_some() {
+        return match (allow_gravatar, gravatar) {
+            (false, _) | (true, Some(None)) => CacheLookup::Missing,
+            (true, Some(Some(texture))) => CacheLookup::Texture(texture),
+            (true, None) => CacheLookup::Fetch {
+                generation,
+                mode: FetchMode::GravatarOnly,
+            },
+        };
+    }
+
+    // Contact status is unknown for this EDS generation. Check it first, but do
+    // not refetch a Gravatar whose result is already cached.
+    let mode = if allow_gravatar && gravatar.is_none() {
+        FetchMode::ContactThenGravatar
+    } else {
+        FetchMode::ContactOnly
+    };
+    CacheLookup::Fetch { generation, mode }
 }
 
 fn gravatar_url(email: &str) -> String {
     let digest = md5::compute(key(email));
-    // d=404 → no image when the sender has no Gravatar, so we fall back to initials.
-    format!("https://www.gravatar.com/avatar/{digest:x}?s=80&d=404")
+    format!("https://www.gravatar.com/avatar/{digest:x}?s=160&d=404")
 }
 
-/// Blocking HTTPS fetch of the Gravatar image bytes. Returns `None` if the
-/// sender has no Gravatar (404) or on any error. Call off the main thread.
-pub fn fetch(email: &str) -> Option<Vec<u8>> {
+/// Blocking sender-avatar lookup. The chain is local vCard PHOTO, optional
+/// Gravatar, then the UI's initials fallback. Call off the main thread.
+pub fn fetch(email: &str, mode: FetchMode) -> FetchOutcome {
+    if mode != FetchMode::GravatarOnly {
+        for bytes in crate::contacts::contact_photos(email) {
+            // Decode/downscale on this background thread. A corrupt candidate
+            // must not hide a valid duplicate or Gravatar fallback.
+            if supported_raster(&bytes) {
+                if let Some(image) = decode_image(&bytes) {
+                    return FetchOutcome::Found(FetchedAvatar {
+                        image,
+                        source: AvatarSource::Contact,
+                    });
+                }
+            }
+        }
+        if mode == FetchMode::ContactOnly {
+            return FetchOutcome::Missing;
+        }
+    }
+
+    match gravatar_image(email) {
+        Ok(Some(image)) => FetchOutcome::Found(FetchedAvatar {
+            image,
+            source: AvatarSource::Gravatar,
+        }),
+        Ok(None) => FetchOutcome::Missing,
+        Err(()) => FetchOutcome::Retry,
+    }
+}
+
+/// Record a completed request. Contact results are stamped with the generation
+/// that was actually queried; stale results are discarded rather than masking a
+/// newly synchronized vCard photo.
+pub fn cache_result(
+    email: &str,
+    generation: u64,
+    mode: FetchMode,
+    outcome: FetchOutcome,
+) -> bool {
+    let key = key(email);
+    let generation_current = crate::contacts::photo_generation() == generation;
+    match outcome {
+        FetchOutcome::Found(fetched) => {
+            let bytes = gtk::glib::Bytes::from(fetched.image.pixels.as_ref());
+            let texture = Some(
+                gtk::gdk::MemoryTexture::new(
+                    fetched.image.width,
+                    fetched.image.height,
+                    gtk::gdk::MemoryFormat::R8g8b8a8,
+                    &bytes,
+                    fetched.image.width as usize * 4,
+                )
+                .upcast::<gtk::gdk::Texture>(),
+            );
+            match fetched.source {
+                AvatarSource::Contact if generation_current => {
+                    CONTACT_CACHE.with(|cache| {
+                        cache.borrow_mut().insert(
+                            key,
+                            ContactCache {
+                                generation,
+                                texture,
+                            },
+                        );
+                    });
+                }
+                AvatarSource::Gravatar => {
+                    GRAVATAR_CACHE.with(|cache| {
+                        cache.borrow_mut().insert(key.clone(), texture);
+                    });
+                    if mode == FetchMode::ContactThenGravatar && generation_current {
+                        cache_missing_contact(&key, generation);
+                    }
+                }
+                AvatarSource::Contact => {}
+            }
+        }
+        FetchOutcome::Missing => {
+            if mode != FetchMode::GravatarOnly && generation_current {
+                cache_missing_contact(&key, generation);
+            }
+            if mode != FetchMode::ContactOnly {
+                GRAVATAR_CACHE.with(|cache| {
+                    cache.borrow_mut().insert(key, None);
+                });
+            }
+        }
+        FetchOutcome::Retry => {
+            if mode == FetchMode::ContactThenGravatar && generation_current {
+                cache_missing_contact(&key, generation);
+            }
+        }
+    }
+    !generation_current && mode != FetchMode::GravatarOnly
+}
+
+fn cache_missing_contact(email: &str, generation: u64) {
+    CONTACT_CACHE.with(|cache| {
+        cache.borrow_mut().insert(
+            email.to_string(),
+            ContactCache {
+                generation,
+                texture: None,
+            },
+        );
+    });
+}
+
+// Raw Gravatar results coalesce duplicate rows for one sender and preserve a
+// definitive 404 across list rebuilds. Transient failures are never cached.
+enum RawGravatar {
+    Found(DecodedImage),
+    Missing,
+    RetryAfter(std::time::Instant),
+}
+
+type RawGravatarCache = HashMap<String, RawGravatar>;
+static GRAVATAR_BYTES: OnceLock<Mutex<RawGravatarCache>> = OnceLock::new();
+static GRAVATAR_EMAIL_LOCKS: OnceLock<Mutex<HashMap<String, Arc<Mutex<()>>>>> = OnceLock::new();
+static GRAVATAR_GATE: OnceLock<(Mutex<usize>, Condvar)> = OnceLock::new();
+const MAX_GRAVATAR_REQUESTS: usize = 4;
+
+struct GravatarSlot;
+
+impl GravatarSlot {
+    fn acquire() -> Self {
+        let (active, wake) = GRAVATAR_GATE.get_or_init(|| (Mutex::new(0), Condvar::new()));
+        let mut active = active.lock().unwrap_or_else(|p| p.into_inner());
+        while *active >= MAX_GRAVATAR_REQUESTS {
+            active = wake.wait(active).unwrap_or_else(|p| p.into_inner());
+        }
+        *active += 1;
+        Self
+    }
+}
+
+impl Drop for GravatarSlot {
+    fn drop(&mut self) {
+        let (active, wake) = GRAVATAR_GATE.get().expect("Gravatar gate initialized");
+        let mut active = active.lock().unwrap_or_else(|p| p.into_inner());
+        *active = active.saturating_sub(1);
+        wake.notify_one();
+    }
+}
+
+fn gravatar_image(email: &str) -> Result<Option<DecodedImage>, ()> {
     use std::io::Read;
-    let resp = ureq::get(&gravatar_url(email)).call().ok()?;
-    let mut buf = Vec::new();
-    resp.into_reader()
-        .take(2_000_000)
-        .read_to_end(&mut buf)
-        .ok()?;
-    (!buf.is_empty()).then_some(buf)
+
+    const MAX_BYTES: usize = 2_000_000;
+    let key = key(email);
+    let email_lock = {
+        let mut locks = GRAVATAR_EMAIL_LOCKS
+            .get_or_init(|| Mutex::new(HashMap::new()))
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        locks
+            .entry(key.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    };
+    let _email_guard = email_lock.lock().unwrap_or_else(|p| p.into_inner());
+    {
+        let mut cache = GRAVATAR_BYTES
+            .get_or_init(|| Mutex::new(HashMap::new()))
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        match cache.get(&key) {
+            Some(RawGravatar::Found(bytes)) => return Ok(Some(bytes.clone())),
+            Some(RawGravatar::Missing) => return Ok(None),
+            Some(RawGravatar::RetryAfter(when)) if *when > std::time::Instant::now() => {
+                return Err(());
+            }
+            Some(RawGravatar::RetryAfter(_)) => {
+                cache.remove(&key);
+            }
+            None => {}
+        }
+    }
+
+    let _slot = GravatarSlot::acquire();
+    let response = match ureq::get(&gravatar_url(email))
+        .timeout(std::time::Duration::from_secs(10))
+        .call()
+    {
+        Ok(response) => response,
+        Err(ureq::Error::Status(404, _)) => {
+            GRAVATAR_BYTES
+                .get()
+                .unwrap()
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .insert(key, RawGravatar::Missing);
+            return Ok(None);
+        }
+        Err(_) => {
+            cache_gravatar_retry(key);
+            return Err(());
+        }
+    };
+    let mut bytes = Vec::new();
+    if response
+        .into_reader()
+        .take(MAX_BYTES as u64 + 1)
+        .read_to_end(&mut bytes)
+        .is_err()
+    {
+        cache_gravatar_retry(key);
+        return Err(());
+    }
+    let image = if bytes.len() <= MAX_BYTES && supported_raster(&bytes) {
+        decode_image(&bytes)
+    } else {
+        None
+    };
+    let Some(image) = image else {
+        // Only a 404 is a definitive absence. A malformed 200 response may be a
+        // proxy/captive-portal/CDN failure, so coalesce it behind a short retry.
+        cache_gravatar_retry(key);
+        return Err(());
+    };
+    GRAVATAR_BYTES
+        .get()
+        .unwrap()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .insert(key, RawGravatar::Found(image.clone()));
+    Ok(Some(image))
 }
 
-/// Decode image bytes into a texture and cache it under `email` (main thread).
-pub fn decode_and_cache(email: &str, bytes: &[u8]) -> Option<gtk::gdk::Texture> {
-    let glib_bytes = gtk::glib::Bytes::from(bytes);
-    let tex = gtk::gdk::Texture::from_bytes(&glib_bytes).ok()?;
-    store(email, tex.clone());
-    Some(tex)
+fn cache_gravatar_retry(key: String) {
+    GRAVATAR_BYTES
+        .get()
+        .expect("Gravatar cache initialized")
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .insert(
+            key,
+            RawGravatar::RetryAfter(
+                std::time::Instant::now() + std::time::Duration::from_secs(30),
+            ),
+        );
+}
+
+/// Only hand known raster formats to GdkPixbuf. In particular, an address-book
+/// entry cannot smuggle an SVG with external references into the decoder.
+fn supported_raster(bytes: &[u8]) -> bool {
+    bytes.starts_with(b"\x89PNG\r\n\x1a\n")
+        || bytes.starts_with(&[0xff, 0xd8, 0xff])
+        || bytes.starts_with(b"GIF87a")
+        || bytes.starts_with(b"GIF89a")
+        || bytes.starts_with(b"BM")
+        || (bytes.starts_with(b"RIFF") && bytes.get(8..12) == Some(b"WEBP"))
+}
+
+/// Decode through a size-prepared PixbufLoader so large source images are
+/// downscaled during decoding. A pixel limit also rejects decompression bombs.
+fn decode_image(bytes: &[u8]) -> Option<DecodedImage> {
+    use gtk::gdk_pixbuf::prelude::*;
+
+    const MAX_PIXELS: i64 = 4_194_304;
+    const THUMBNAIL_EDGE: i32 = 160;
+    let loader = gtk::gdk_pixbuf::PixbufLoader::new();
+    let valid = Rc::new(Cell::new(false));
+    loader.connect_size_prepared({
+        let valid = valid.clone();
+        move |loader, width, height| {
+            if width <= 0 || height <= 0 || i64::from(width) * i64::from(height) > MAX_PIXELS {
+                loader.set_size(1, 1);
+                return;
+            }
+            valid.set(true);
+            let longest = width.max(height);
+            if longest > THUMBNAIL_EDGE {
+                loader.set_size(
+                    (width * THUMBNAIL_EDGE / longest).max(1),
+                    (height * THUMBNAIL_EDGE / longest).max(1),
+                );
+            }
+        }
+    });
+    if loader.write(bytes).is_err() {
+        let _ = loader.close();
+        return None;
+    }
+    if loader.close().is_err() || !valid.get() {
+        return None;
+    }
+    let pixbuf = loader.pixbuf()?;
+    if pixbuf.bits_per_sample() != 8 || pixbuf.n_channels() < 3 {
+        return None;
+    }
+    let width = pixbuf.width();
+    let height = pixbuf.height();
+    let channels = pixbuf.n_channels() as usize;
+    let rowstride = pixbuf.rowstride() as usize;
+    let source = pixbuf.read_pixel_bytes();
+    let source = source.as_ref();
+    let mut pixels = Vec::with_capacity(width as usize * height as usize * 4);
+    for y in 0..height as usize {
+        for x in 0..width as usize {
+            let offset = y * rowstride + x * channels;
+            pixels.extend_from_slice(&source[offset..offset + 3]);
+            pixels.push(if channels >= 4 { source[offset + 3] } else { 255 });
+        }
+    }
+    Some(DecodedImage {
+        pixels: pixels.into(),
+        width,
+        height,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::supported_raster;
+
+    #[test]
+    fn accepts_common_rasters_but_not_svg() {
+        assert!(supported_raster(b"\x89PNG\r\n\x1a\nrest"));
+        assert!(supported_raster(b"\xff\xd8\xffrest"));
+        assert!(!supported_raster(b"<svg xmlns='http://www.w3.org/2000/svg'/>"));
+    }
 }

--- a/src/contacts.rs
+++ b/src/contacts.rs
@@ -5,8 +5,10 @@
 //! Writing goes through the EDS D-Bus API so changes are tracked by EDS and
 //! synced back to CardDAV servers.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, SystemTime};
 
 /// A name + email pair from the address book.
 #[derive(Debug, Clone)]
@@ -152,6 +154,286 @@ pub fn read_contacts() -> Vec<Contact> {
     out
 }
 
+/// Photo bytes and the EDS database state they came from. The inexpensive
+/// fingerprint check lets a long-running Vireo notice CardDAV synchronizations
+/// without subscribing to backend-specific EDS signals.
+#[derive(Clone)]
+struct PhotoLocation {
+    db: PathBuf,
+    uid: String,
+    cached_book: bool,
+}
+
+struct ContactPhotoIndex {
+    photos: HashMap<String, Vec<PhotoLocation>>,
+    fingerprint: Vec<(PathBuf, u64, u128)>,
+    generation: u64,
+    ready: bool,
+}
+
+static CONTACT_PHOTOS: OnceLock<Arc<Mutex<ContactPhotoIndex>>> = OnceLock::new();
+static PHOTO_LOAD_STARTED: OnceLock<()> = OnceLock::new();
+static PHOTO_WATCH_STARTED: OnceLock<()> = OnceLock::new();
+type PhotoChangeCallback = Box<dyn Fn() + Send + Sync + 'static>;
+static PHOTO_CHANGE_CALLBACKS: OnceLock<Mutex<Vec<PhotoChangeCallback>>> = OnceLock::new();
+const PHOTO_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
+
+fn new_photo_index() -> Arc<Mutex<ContactPhotoIndex>> {
+    Arc::new(Mutex::new(ContactPhotoIndex {
+        photos: HashMap::new(),
+        fingerprint: Vec::new(),
+        generation: 1,
+        ready: false,
+    }))
+}
+
+fn load_stable_photo_index() -> (HashMap<String, Vec<PhotoLocation>>, Vec<(PathBuf, u64, u128)>) {
+    let mut last = (HashMap::new(), Vec::new());
+    for _ in 0..3 {
+        let before = photo_db_fingerprint();
+        let photos = load_contact_photo_index();
+        let after = photo_db_fingerprint();
+        last = (photos, after.clone());
+        if before == after {
+            break;
+        }
+    }
+    last
+}
+
+fn notify_photo_change() {
+    if let Some(callbacks) = PHOTO_CHANGE_CALLBACKS.get() {
+        for callback in callbacks.lock().unwrap_or_else(|p| p.into_inner()).iter() {
+            callback();
+        }
+    }
+}
+
+fn start_photo_load() {
+    PHOTO_LOAD_STARTED.get_or_init(|| {
+        let index = CONTACT_PHOTOS.get_or_init(new_photo_index).clone();
+        let _ = std::thread::Builder::new()
+            .name("eds-photo-load".into())
+            .spawn(move || {
+                let (photos, fingerprint) = load_stable_photo_index();
+                let mut current = index.lock().unwrap_or_else(|p| p.into_inner());
+                current.photos = photos;
+                current.fingerprint = fingerprint;
+                current.generation = current.generation.wrapping_add(1).max(1);
+                current.ready = true;
+                drop(current);
+                notify_photo_change();
+            });
+    });
+}
+
+fn start_photo_watcher() {
+    PHOTO_WATCH_STARTED.get_or_init(|| {
+        let index = CONTACT_PHOTOS.get_or_init(new_photo_index).clone();
+        let _ = std::thread::Builder::new()
+            .name("eds-photo-watch".into())
+            .spawn(move || loop {
+                std::thread::sleep(PHOTO_REFRESH_INTERVAL);
+                let fingerprint = photo_db_fingerprint();
+                let changed = {
+                    let current = index.lock().unwrap_or_else(|p| p.into_inner());
+                    fingerprint != current.fingerprint
+                };
+                if !changed {
+                    continue;
+                }
+                // Scan outside the lock. UI lookups continue using the previous
+                // immutable snapshot until the replacement is ready.
+                let (photos, stable_fingerprint) = load_stable_photo_index();
+                let mut current = index.lock().unwrap_or_else(|p| p.into_inner());
+                current.photos = photos;
+                current.fingerprint = stable_fingerprint;
+                current.generation = current.generation.wrapping_add(1).max(1);
+                drop(current);
+                notify_photo_change();
+            });
+    });
+}
+
+pub fn watch_photo_changes<F: Fn() + Send + Sync + 'static>(callback: F) {
+    PHOTO_CHANGE_CALLBACKS
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .push(Box::new(callback));
+    start_photo_load();
+    start_photo_watcher();
+}
+
+/// Current index generation. Avatar textures and negative results use this to
+/// invalidate themselves after an EDS/CardDAV database change.
+pub fn photo_generation() -> u64 {
+    start_photo_load();
+    start_photo_watcher();
+    CONTACT_PHOTOS
+        .get_or_init(new_photo_index)
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .generation
+}
+
+pub fn photos_ready() -> bool {
+    start_photo_load();
+    CONTACT_PHOTOS
+        .get_or_init(new_photo_index)
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .ready
+}
+
+/// Find contact-photo candidates by email in the local EDS caches. Multiple
+/// books can contain the same address; the avatar loader tries each candidate.
+/// CardDAV backends such as Nextcloud keep PHOTO in the cached vCard, so this
+/// does not contact the address-book server or disclose the sender address to a third
+/// party.
+pub fn contact_photos(email: &str) -> Vec<Arc<[u8]>> {
+    let key = email.trim().to_lowercase();
+    if key.is_empty() {
+        return Vec::new();
+    }
+    start_photo_load();
+    start_photo_watcher();
+    let locations = CONTACT_PHOTOS
+        .get_or_init(new_photo_index)
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .photos
+        .get(&key)
+        .cloned()
+        .unwrap_or_default();
+    locations
+        .iter()
+        .filter_map(read_photo_at)
+        .map(Arc::from)
+        .collect()
+}
+
+fn photo_db_fingerprint() -> Vec<(PathBuf, u64, u128)> {
+    let mut files = Vec::new();
+    for db in photo_db_paths() {
+        files.push(db.clone());
+        for suffix in ["-journal", "-wal"] {
+            files.push(PathBuf::from(format!("{}{suffix}", db.to_string_lossy())));
+        }
+    }
+    files.sort();
+    files
+        .into_iter()
+        .filter_map(|path| {
+            let metadata = std::fs::metadata(&path).ok()?;
+            let modified = metadata
+                .modified()
+                .unwrap_or(SystemTime::UNIX_EPOCH)
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos();
+            Some((path, metadata.len(), modified))
+        })
+        .collect()
+}
+
+fn photo_db_paths() -> Vec<PathBuf> {
+    let mut dbs = Vec::new();
+    if let Some(dir) = data_dir() {
+        dbs.extend(find_dbs(&dir, "contacts.db"));
+    }
+    if let Some(dir) = cache_dir() {
+        dbs.extend(find_dbs(&dir, "cache.db"));
+    }
+    dbs.sort();
+    dbs
+}
+
+fn load_contact_photo_index() -> HashMap<String, Vec<PhotoLocation>> {
+    let mut photos = HashMap::new();
+    if let Some(dir) = data_dir() {
+        for db in find_dbs(&dir, "contacts.db") {
+            read_photo_locations(
+                &db,
+                "SELECT e.value, f.uid FROM folder_id f \
+                 JOIN folder_id_email_list e ON f.uid = e.uid \
+                 WHERE f.vcard LIKE '%PHOTO%'",
+                false,
+                &mut photos,
+            );
+        }
+    }
+    if let Some(dir) = cache_dir() {
+        for db in find_dbs(&dir, "cache.db") {
+            read_photo_locations(
+                &db,
+                "SELECT e.value, o.ECacheUID FROM ECacheObjects o \
+                 JOIN attrlist_email_list e ON o.ECacheUID = e.uid \
+                 WHERE o.ECacheOBJ LIKE '%PHOTO%'",
+                true,
+                &mut photos,
+            );
+        }
+    }
+    tracing::debug!(count = photos.len(), "indexed EDS contact photos");
+    photos
+}
+
+fn read_photo_locations(
+    path: &std::path::Path,
+    query: &str,
+    cached_book: bool,
+    photos: &mut HashMap<String, Vec<PhotoLocation>>,
+) {
+    let conn = match open_book_db(path) {
+        Ok(conn) => conn,
+        Err(e) => {
+            tracing::warn!("contacts: cannot open {} for photos: {e}", path.display());
+            return;
+        }
+    };
+    let mut stmt = match conn.prepare(query) {
+        Ok(stmt) => stmt,
+        Err(e) => {
+            tracing::warn!("contacts: photo query failed on {}: {e}", path.display());
+            return;
+        }
+    };
+    let rows = match stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    }) {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::warn!("contacts: photo rows failed on {}: {e}", path.display());
+            return;
+        }
+    };
+    for (email, uid) in rows.flatten() {
+        let key = email.trim().to_lowercase();
+        if !key.is_empty() {
+            let location = PhotoLocation {
+                db: path.to_path_buf(),
+                uid,
+                cached_book,
+            };
+            photos.entry(key).or_default().push(location);
+        }
+    }
+}
+
+fn read_photo_at(location: &PhotoLocation) -> Option<Vec<u8>> {
+    let conn = open_book_db(&location.db).ok()?;
+    let query = if location.cached_book {
+        "SELECT ECacheOBJ FROM ECacheObjects WHERE ECacheUID = ?1"
+    } else {
+        "SELECT vcard FROM folder_id WHERE uid = ?1"
+    };
+    let vcard: Option<String> = conn
+        .query_row(query, [&location.uid], |row| row.get(0))
+        .ok()?;
+    vcard.as_deref().and_then(vcard_photo)
+}
+
 fn find_dbs(root: &std::path::Path, file: &str) -> Vec<PathBuf> {
     let mut dbs = Vec::new();
     if let Ok(entries) = std::fs::read_dir(root) {
@@ -162,19 +444,23 @@ fn find_dbs(root: &std::path::Path, file: &str) -> Vec<PathBuf> {
             }
         }
     }
+    dbs.sort();
     dbs
 }
 
 /// Extract the display name (`FN`) from a vCard, preserving its capitalisation.
 /// Handles line folding (a CRLF/LF followed by a space or tab continues the
 /// previous line) and the standard text escapes.
-fn vcard_display_name(vcard: &str) -> Option<String> {
-    let unfolded = vcard
+fn unfold_vcard(vcard: &str) -> String {
+    vcard
         .replace("\r\n ", "")
         .replace("\r\n\t", "")
         .replace("\n ", "")
-        .replace("\n\t", "");
-    for line in unfolded.lines() {
+        .replace("\n\t", "")
+}
+
+fn vcard_display_name(vcard: &str) -> Option<String> {
+    for line in unfold_vcard(vcard).lines() {
         let Some((prop, value)) = line.split_once(':') else {
             continue;
         };
@@ -190,6 +476,97 @@ fn vcard_display_name(vcard: &str) -> Option<String> {
         }
     }
     None
+}
+
+/// Decode an embedded vCard PHOTO. Handles both Nextcloud's escaped data URI
+/// form and the conventional `PHOTO;ENCODING=b` form. Remote PHOTO URLs are
+/// deliberately not fetched, both for privacy and to avoid tracking.
+fn vcard_photo(vcard: &str) -> Option<Vec<u8>> {
+    use base64::Engine as _;
+
+    const MAX_PHOTO_BYTES: usize = 2_000_000;
+    for line in unfold_vcard(vcard).lines() {
+        let Some((property, raw_value)) = line.split_once(':') else {
+            continue;
+        };
+        let name = property
+            .split(';')
+            .next()
+            .unwrap_or("")
+            .rsplit('.')
+            .next()
+            .unwrap_or("")
+            .trim();
+        if !name.eq_ignore_ascii_case("PHOTO") {
+            continue;
+        }
+
+        let value = raw_value.replace("\\;", ";").replace("\\,", ",");
+        let property_upper = property.to_ascii_uppercase();
+        let payload = if value.to_ascii_lowercase().starts_with("data:image/") {
+            let Some((metadata, payload)) = value.split_once(',') else {
+                continue;
+            };
+            if !metadata.to_ascii_lowercase().ends_with(";base64") {
+                continue;
+            }
+            payload
+        } else if property_upper.contains("ENCODING=B")
+            || property_upper.contains("ENCODING=BASE64")
+        {
+            value.as_str()
+        } else if value.to_ascii_lowercase().starts_with("file://") {
+            if let Some(bytes) = read_eds_photo_file(&value, MAX_PHOTO_BYTES) {
+                return Some(bytes);
+            }
+            continue;
+        } else {
+            // Never fetch http(s) or other remote PHOTO URIs implicitly.
+            continue;
+        };
+
+        let encoded: String = payload.chars().filter(|c| !c.is_ascii_whitespace()).collect();
+        // Base64 expands data by roughly 4/3. Reject oversized input before
+        // allocating the decoded image buffer.
+        if encoded.len() > (MAX_PHOTO_BYTES * 4 / 3 + 4) {
+            continue;
+        }
+        if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(encoded) {
+            if !bytes.is_empty() && bytes.len() <= MAX_PHOTO_BYTES {
+                return Some(bytes);
+            }
+        }
+    }
+    None
+}
+
+/// Read an EDS-materialized `file://` photo, but only from an address-book data
+/// or cache directory. A CardDAV vCard must not be able to make Vireo read an
+/// arbitrary local file.
+fn read_eds_photo_file(uri: &str, max_bytes: usize) -> Option<Vec<u8>> {
+    use std::io::Read;
+
+    let (path, host) = gtk::glib::filename_from_uri(uri).ok()?;
+    if host.is_some() {
+        return None;
+    }
+    let path = path.canonicalize().ok()?;
+    let allowed = [data_dir(), cache_dir()]
+        .into_iter()
+        .flatten()
+        .filter_map(|root| root.canonicalize().ok())
+        .any(|root| path.starts_with(root));
+    if !allowed {
+        return None;
+    }
+
+    let mut bytes = Vec::new();
+    std::fs::File::open(path)
+        .ok()?
+        .take(max_bytes as u64 + 1)
+        .read_to_end(&mut bytes)
+        .ok()?;
+    (!bytes.is_empty() && bytes.len() <= max_bytes).then_some(bytes)
 }
 
 /// Unescape a vCard TEXT value: `\n`/`\N` → newline, `\,` → `,`, `\;` → `;`,
@@ -211,21 +588,24 @@ fn unescape_vcard_text(s: &str) -> String {
     out
 }
 
-fn read_book_db(path: &std::path::Path, query: &str, out: &mut Vec<Contact>, seen: &mut HashSet<String>) {
+fn open_book_db(path: &std::path::Path) -> rusqlite::Result<rusqlite::Connection> {
     use rusqlite::OpenFlags;
     let flags = OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI;
     // Under Flatpak the book DB lives on a read-only host mount; a WAL database
     // can't be opened read-only there (it needs to touch the -shm/-wal files), so
     // open it `immutable=1` to read the committed snapshot without any locking.
-    let conn = if crate::platform::is_flatpak() {
+    if crate::platform::is_flatpak() {
         rusqlite::Connection::open_with_flags(
             format!("file:{}?immutable=1", path.to_string_lossy()),
             flags,
         )
     } else {
         rusqlite::Connection::open_with_flags(path, flags)
-    };
-    let conn = match conn {
+    }
+}
+
+fn read_book_db(path: &std::path::Path, query: &str, out: &mut Vec<Contact>, seen: &mut HashSet<String>) {
+    let conn = match open_book_db(path) {
         Ok(c) => c,
         Err(e) => {
             tracing::warn!("contacts: cannot open {}: {e}", path.display());
@@ -468,7 +848,10 @@ fn vcard_for(name: &str, email: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::vcard_display_name;
+    use super::{vcard_display_name, vcard_photo};
+
+    const ONE_PIXEL_PNG: &str =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
 
     #[test]
     fn fn_preserves_case() {
@@ -499,5 +882,28 @@ mod tests {
     fn empty_or_missing_fn() {
         assert_eq!(vcard_display_name("FN:\r\nN:x;;;;\r\n"), None);
         assert_eq!(vcard_display_name("N:Doe;John;;;\r\n"), None);
+    }
+
+    #[test]
+    fn photo_decodes_nextcloud_data_uri() {
+        let vcard = format!("item1.PHOTO:data:image/image/png\\;base64\\,{ONE_PIXEL_PNG}\r\n");
+        let photo = vcard_photo(&vcard).unwrap();
+        assert_eq!(&photo[..8], b"\x89PNG\r\n\x1a\n");
+    }
+
+    #[test]
+    fn photo_decodes_folded_encoding_b() {
+        let split = ONE_PIXEL_PNG.len() / 2;
+        let vcard = format!(
+            "PHOTO;ENCODING=b;TYPE=PNG:{}\r\n {}\r\n",
+            &ONE_PIXEL_PNG[..split],
+            &ONE_PIXEL_PNG[split..]
+        );
+        assert!(vcard_photo(&vcard).is_some());
+    }
+
+    #[test]
+    fn photo_does_not_fetch_remote_uri() {
+        assert!(vcard_photo("PHOTO;VALUE=uri:https://example.com/tracker.png\r\n").is_none());
     }
 }

--- a/src/ui/message_list.rs
+++ b/src/ui/message_list.rs
@@ -108,7 +108,12 @@ impl FactoryComponent for MessageRow {
     type Init = RowInit;
     type Input = MessageRowInput;
     type Output = MessageRowOutput;
-    type CommandOutput = Option<Vec<u8>>;
+    type CommandOutput = (
+        String,
+        u64,
+        crate::avatar::FetchMode,
+        crate::avatar::FetchOutcome,
+    );
     type ParentWidget = gtk::ListBox;
 
     view! {
@@ -363,17 +368,25 @@ impl FactoryComponent for MessageRow {
             thread_unread,
         };
 
-        if model.gravatar {
-            let email = model.msg.from_addr.clone();
-            if let Some(tex) = crate::avatar::cached(&email) {
-                model.avatar_texture = Some(tex);
-            } else if !email.is_empty() {
-                sender.oneshot_command(async move {
-                    tokio::task::spawn_blocking(move || crate::avatar::fetch(&email))
+        let email = model.msg.from_addr.clone();
+        if !email.is_empty() {
+            match crate::avatar::lookup(&email, model.gravatar) {
+                crate::avatar::CacheLookup::Texture(texture) => {
+                    model.avatar_texture = Some(texture);
+                }
+                crate::avatar::CacheLookup::Missing => {}
+                crate::avatar::CacheLookup::Fetch { generation, mode } => {
+                    let requested_email = email.clone();
+                    sender.oneshot_command(async move {
+                        let lookup_email = requested_email.clone();
+                        let outcome = tokio::task::spawn_blocking(move || {
+                            crate::avatar::fetch(&lookup_email, mode)
+                        })
                         .await
-                        .ok()
-                        .flatten()
-                });
+                        .unwrap_or(crate::avatar::FetchOutcome::Retry);
+                        (requested_email, generation, mode, outcome)
+                    });
+                }
             }
         }
 
@@ -421,9 +434,34 @@ impl FactoryComponent for MessageRow {
         }
     }
 
-    fn update_cmd(&mut self, bytes: Self::CommandOutput, _sender: FactorySender<Self>) {
-        if let Some(bytes) = bytes {
-            self.avatar_texture = crate::avatar::decode_and_cache(&self.msg.from_addr, &bytes);
+    fn update_cmd(
+        &mut self,
+        (email, generation, mode, outcome): Self::CommandOutput,
+        sender: FactorySender<Self>,
+    ) {
+        let retry_stale = crate::avatar::cache_result(&email, generation, mode, outcome);
+        if self.msg.from_addr.eq_ignore_ascii_case(&email) {
+            match crate::avatar::lookup(&email, self.gravatar) {
+                crate::avatar::CacheLookup::Texture(texture) => {
+                    self.avatar_texture = Some(texture);
+                }
+                crate::avatar::CacheLookup::Missing => self.avatar_texture = None,
+                crate::avatar::CacheLookup::Fetch { generation, mode } => {
+                    self.avatar_texture = None;
+                    if retry_stale {
+                        let requested_email = email.clone();
+                        sender.oneshot_command(async move {
+                            let lookup_email = requested_email.clone();
+                            let outcome = tokio::task::spawn_blocking(move || {
+                                crate::avatar::fetch(&lookup_email, mode)
+                            })
+                            .await
+                            .unwrap_or(crate::avatar::FetchOutcome::Retry);
+                            (requested_email, generation, mode, outcome)
+                        });
+                    }
+                }
+            }
         }
     }
 
@@ -774,6 +812,7 @@ pub enum MessageListInput {
     /// Whether conversations start expanded (true) or collapsed (false).
     SetThreadsExpanded(bool),
     SetGravatar(bool),
+    ContactPhotosChanged,
     SetColorize(bool),
     /// The local day rolled over — re-render rows so "Today" stays accurate.
     DayChanged,
@@ -1272,6 +1311,7 @@ impl SimpleComponent for MessageList {
                     self.rebuild();
                 }
             }
+            MessageListInput::ContactPhotosChanged => self.rebuild_preserving_scroll(),
             MessageListInput::SetColorize(on) => {
                 if self.colorize != on {
                     self.colorize = on;

--- a/src/ui/message_view.rs
+++ b/src/ui/message_view.rs
@@ -68,6 +68,8 @@ pub enum MessageViewInput {
     /// Set the message-content theme: `None` follows the system, `Some(dark)`
     /// forces light/dark for email content only (not the app UI).
     SetContentTheme(Option<bool>),
+    /// EDS/CardDAV changed; re-resolve the current sender photo.
+    ContactPhotosChanged,
     /// The WebView finished loading the current document — reveal it.
     Rendered,
     /// A conversation message header was double-clicked — open that message in
@@ -90,8 +92,13 @@ impl Component for MessageView {
     type Init = ();
     type Input = MessageViewInput;
     type Output = MessageViewOutput;
-    /// (message id, fetched Gravatar bytes) — id guards against stale results.
-    type CommandOutput = (u32, Option<Vec<u8>>);
+    /// Requested sender + setting + result, used to reject stale async lookups.
+    type CommandOutput = (
+        String,
+        u64,
+        crate::avatar::FetchMode,
+        crate::avatar::FetchOutcome,
+    );
 
     view! {
         gtk::Stack {
@@ -414,6 +421,7 @@ impl Component for MessageView {
                     }
                 }
             }
+            MessageViewInput::ContactPhotosChanged => self.load_avatar(&sender),
             MessageViewInput::Rendered => {
                 self.webview_ready = true;
             }
@@ -431,32 +439,47 @@ impl Component for MessageView {
 
     fn update_cmd(
         &mut self,
-        (message_id, bytes): Self::CommandOutput,
-        _sender: ComponentSender<Self>,
+        (email, generation, mode, outcome): Self::CommandOutput,
+        sender: ComponentSender<Self>,
         _root: &Self::Root,
     ) {
-        // Ignore results for a message that's no longer shown.
-        let still_current = self
-            .current
-            .as_ref()
-            .is_some_and(|m| m.id == message_id);
-        if !still_current {
-            return;
-        }
-        if let (Some(bytes), Some(m)) = (bytes, self.current.as_ref()) {
-            self.avatar_texture = crate::avatar::decode_and_cache(&m.from_addr, &bytes);
+        let retry_stale = crate::avatar::cache_result(&email, generation, mode, outcome);
+        // IMAP UIDs are only mailbox-scoped, so correlate by the sender that
+        // actually initiated the lookup rather than the numeric message id.
+        let still_current = self.current.as_ref().is_some_and(|message| {
+            message.from_addr.eq_ignore_ascii_case(&email)
+        });
+        if still_current {
+            match crate::avatar::lookup(&email, self.gravatar) {
+                crate::avatar::CacheLookup::Texture(texture) => {
+                    self.avatar_texture = Some(texture);
+                }
+                crate::avatar::CacheLookup::Missing => self.avatar_texture = None,
+                crate::avatar::CacheLookup::Fetch { generation, mode } => {
+                    self.avatar_texture = None;
+                    if retry_stale {
+                        let requested_email = email.clone();
+                        sender.oneshot_command(async move {
+                            let lookup_email = requested_email.clone();
+                            let outcome = tokio::task::spawn_blocking(move || {
+                                crate::avatar::fetch(&lookup_email, mode)
+                            })
+                            .await
+                            .unwrap_or(crate::avatar::FetchOutcome::Retry);
+                            (requested_email, generation, mode, outcome)
+                        });
+                    }
+                }
+            }
         }
     }
 }
 
 impl MessageView {
-    /// Set the sender avatar: cached texture if available, otherwise (when
-    /// Gravatar is enabled) kick off a background fetch keyed to this message.
+    /// Set the sender avatar from local contacts, with optional Gravatar
+    /// fallback, correlating background results by sender address.
     fn load_avatar(&mut self, sender: &ComponentSender<Self>) {
         self.avatar_texture = None;
-        if !self.gravatar {
-            return;
-        }
         let Some(m) = self.current.as_ref() else {
             return;
         };
@@ -464,18 +487,24 @@ impl MessageView {
         if email.is_empty() {
             return;
         }
-        if let Some(tex) = crate::avatar::cached(&email) {
-            self.avatar_texture = Some(tex);
-            return;
+        match crate::avatar::lookup(&email, self.gravatar) {
+            crate::avatar::CacheLookup::Texture(texture) => {
+                self.avatar_texture = Some(texture);
+            }
+            crate::avatar::CacheLookup::Missing => {}
+            crate::avatar::CacheLookup::Fetch { generation, mode } => {
+                let requested_email = email.clone();
+                sender.oneshot_command(async move {
+                    let lookup_email = requested_email.clone();
+                    let outcome = tokio::task::spawn_blocking(move || {
+                        crate::avatar::fetch(&lookup_email, mode)
+                    })
+                    .await
+                    .unwrap_or(crate::avatar::FetchOutcome::Retry);
+                    (requested_email, generation, mode, outcome)
+                });
+            }
         }
-        let id = m.id;
-        sender.oneshot_command(async move {
-            let bytes = tokio::task::spawn_blocking(move || crate::avatar::fetch(&email))
-                .await
-                .ok()
-                .flatten();
-            (id, bytes)
-        });
     }
 
     /// Whether message content should render dark: the user's forced choice, or

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -231,9 +231,9 @@ impl Component for Preferences {
 
                         #[name = "gravatar_row"]
                         adw::SwitchRow {
-                            set_title: "Load sender avatars (Gravatar)",
-                            set_subtitle: "Sends a hash of each sender's email to Gravatar. \
-                                           When off, colored initials are shown instead.",
+                            set_title: "Use Gravatar when a contact has no photo",
+                            set_subtitle: "Local GNOME Contacts photos are always preferred. \
+                                           Gravatar sends a hash of the sender's email.",
                             connect_active_notify[sender] => move |row| {
                                 sender.input(PrefInput::ToggleGravatar(row.is_active()));
                             },


### PR DESCRIPTION
## Summary

- resolve sender avatars in this order: local EDS/vCard PHOTO → opt-in Gravatar → coloured initials
- support Nextcloud data-URI PHOTO, standard folded `ENCODING=b`, grouped properties and safe EDS `file://` photos
- index local/CardDAV photo locations in the background and refresh visible avatars when EDS changes without jumping the message list scroll position
- try all duplicate contact candidates and preserve cache provenance so disabling Gravatar immediately hides cached Gravatars
- correlate asynchronous results by sender and EDS generation to prevent wrong/stale avatars
- coalesce duplicate Gravatar lookups, cap concurrency, apply timeouts/backoff, and cache only definitive 404 misses
- reject remote vCard PHOTO URLs and SVG; decode/downscale raster photos off the GTK thread and create bounded 160px textures on the main thread

## Privacy

- local contact photos require no additional CardDAV/network request
- Gravatar remains opt-in and is queried only when no usable local photo exists
- remote PHOTO URLs are never fetched
- local file URIs are canonicalized and restricted to EDS address-book directories

## Testing

- `cargo check --locked`
- `cargo test --locked` — 48 passed
- `cargo clippy --all-targets --locked` — passes; pre-existing style warnings remain
- combined GOA + avatar build: 57 passed
- live EDS/Nextcloud cache indexed 399 sender-photo addresses
- verified and decoded the local vCard PNG for `schavelevoi@basealt.ru`
- multiple independent Codex and Claude review rounds completed and findings addressed
