### PR TITLE
Bug fixes and additional settings for show/hide Attachments button

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -39,7 +39,9 @@ use crate::ui::message_window::{
 };
 use crate::ui::notifications::{NotificationCenter, NotifyInput, NotifyOutput};
 use crate::ui::preferences::{PrefInit, PrefOutput, Preferences};
-use crate::ui::sidebar::{CtxAction, SectionData, Sidebar, SidebarInput, SidebarOutput};
+use crate::ui::sidebar::{
+    CtxAction, SectionData, Sidebar, SidebarInit, SidebarInput, SidebarOutput,
+};
 use crate::worker::{self, MailRequest, OutgoingMessage, WorkerEvent};
 
 /// The currently selected mailbox.
@@ -160,6 +162,8 @@ pub struct AppModel {
     push: bool,
     /// Whether desktop notifications (new mail, error alerts) are posted.
     notifications_enabled: bool,
+    /// Whether the sidebar shows the "Attachments" row.
+    show_attachments: bool,
     /// Whether messages are grouped into conversation threads.
     threading: bool,
     /// Whether conversation threads start expanded in the message list.
@@ -277,6 +281,7 @@ pub enum AppMsg {
     SetFetchInterval(u64),
     SetPush(bool),
     SetNotifications(bool),
+    SetShowAttachments(bool),
     SetPaletteCollapse(u64),
     SetMessageTheme(config::MessageTheme),
     ComposeTo(String),
@@ -757,8 +762,9 @@ impl SimpleComponent for AppModel {
         let collapsed = sidebar_state.collapsed;
         let folders_expanded = sidebar_state.folders_expanded;
 
+        let show_attachments = config::load_show_attachments();
         let sidebar = Sidebar::builder()
-            .launch(icon_only)
+            .launch(SidebarInit { collapsed: icon_only, show_attachments })
             .forward(sender.input_sender(), |out| match out {
                 SidebarOutput::UnifiedSelected => AppMsg::UnifiedSelected,
                 SidebarOutput::AttachmentsSelected => AppMsg::ShowAttachments,
@@ -886,6 +892,7 @@ impl SimpleComponent for AppModel {
             fetch_interval_secs: config::load_fetch_interval(),
             push: config::load_push(),
             notifications_enabled: config::load_notifications(),
+            show_attachments,
             threading: config::load_threading(),
             threads_expanded: config::load_threads_expanded(),
             message_theme: config::load_message_theme(),
@@ -1710,6 +1717,14 @@ impl SimpleComponent for AppModel {
                 }
             }
 
+            AppMsg::SetShowAttachments(on) => {
+                if self.show_attachments != on {
+                    self.show_attachments = on;
+                    self.save_settings();
+                    self.sidebar.emit(SidebarInput::SetShowAttachments(on));
+                }
+            }
+
             AppMsg::SetThreading(on) => {
                 if self.threading != on {
                     self.threading = on;
@@ -1979,6 +1994,7 @@ impl SimpleComponent for AppModel {
                     threads_expanded: self.threads_expanded,
                     message_theme: self.message_theme,
                     notifications: self.notifications_enabled,
+                    show_attachments: self.show_attachments,
                 };
                 let prefs = Preferences::builder()
                     .transient_for(&self.window)
@@ -1994,6 +2010,7 @@ impl SimpleComponent for AppModel {
                         PrefOutput::SetFetchInterval(secs) => AppMsg::SetFetchInterval(secs),
                         PrefOutput::SetPush(on) => AppMsg::SetPush(on),
                         PrefOutput::SetNotifications(on) => AppMsg::SetNotifications(on),
+                        PrefOutput::SetShowAttachments(on) => AppMsg::SetShowAttachments(on),
                         PrefOutput::SetPaletteCollapse(secs) => AppMsg::SetPaletteCollapse(secs),
                         PrefOutput::SetMessageTheme(t) => AppMsg::SetMessageTheme(t),
                         PrefOutput::Closed => AppMsg::ClosePreferences,
@@ -2357,6 +2374,7 @@ impl AppModel {
             self.threads_expanded,
             self.message_theme,
             self.notifications_enabled,
+            self.show_attachments,
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -257,6 +257,7 @@ pub enum AppMsg {
     /// Save attachments delivered from a popout window.
     SaveAttachmentItems(Vec<Attachment>),
     ToggleStar,
+    MarkUnread,
     Archive,
     Delete,
     RowAction { action: RowAction, message: Box<Message> },
@@ -562,6 +563,14 @@ impl SimpleComponent for AppModel {
                                     #[watch]
                                     set_sensitive: model.current.is_some(),
                                     connect_clicked[sender] => move |_| sender.input(AppMsg::AddToContacts),
+                                },
+                                pack_start = &gtk::Button {
+                                    set_icon_name: "co.hyprlab.Vireo-mail-unread-symbolic",
+                                    set_tooltip_text: Some("Mark as Unread"),
+                                    add_css_class: "flat",
+                                    #[watch]
+                                    set_sensitive: model.current.is_some(),
+                                    connect_clicked[sender] => move |_| sender.input(AppMsg::MarkUnread),
                                 },
                                 pack_start = &gtk::Button {
                                     set_tooltip_text: Some("Flag"),
@@ -1463,6 +1472,12 @@ impl SimpleComponent for AppModel {
             AppMsg::ToggleStar => {
                 if let Some(m) = self.current.clone() {
                     self.set_star(&m, !m.starred);
+                }
+            }
+
+            AppMsg::MarkUnread => {
+                if let Some(m) = self.current.clone() {
+                    self.set_read(&m, false);
                 }
             }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -367,6 +367,10 @@ struct PrivacyFile {
     /// Whether to post desktop notifications (new mail, error alerts).
     #[serde(default = "default_notifications")]
     notifications: bool,
+    /// Whether the sidebar shows the "Attachments" row (gallery of every
+    /// account's attachments).
+    #[serde(default = "default_show_attachments")]
+    show_attachments: bool,
 }
 
 fn default_fetch_interval() -> u64 {
@@ -389,6 +393,10 @@ fn default_notifications() -> bool {
     true
 }
 
+fn default_show_attachments() -> bool {
+    true
+}
+
 impl Default for PrivacyFile {
     fn default() -> Self {
         Self {
@@ -402,6 +410,7 @@ impl Default for PrivacyFile {
             threads_expanded: false,
             message_theme: MessageTheme::default(),
             notifications: default_notifications(),
+            show_attachments: default_show_attachments(),
         }
     }
 }
@@ -470,6 +479,11 @@ pub fn load_notifications() -> bool {
     load_privacy().notifications
 }
 
+/// Whether the sidebar shows the "Attachments" row.
+pub fn load_show_attachments() -> bool {
+    load_privacy().show_attachments
+}
+
 /// Persist all app settings together (so no field is clobbered).
 #[allow(clippy::too_many_arguments)]
 pub fn save_privacy(
@@ -483,6 +497,7 @@ pub fn save_privacy(
     threads_expanded: bool,
     message_theme: MessageTheme,
     notifications: bool,
+    show_attachments: bool,
 ) {
     let Some(path) = privacy_path() else {
         return;
@@ -501,6 +516,7 @@ pub fn save_privacy(
         threads_expanded,
         message_theme,
         notifications,
+        show_attachments,
     };
     match toml::to_string_pretty(&file) {
         Ok(toml) => {

--- a/src/goa.rs
+++ b/src/goa.rs
@@ -243,7 +243,17 @@ fn watch_loop<F: Fn()>(on_change: &F) -> Result<(), Box<dyn std::error::Error>> 
 /// Fetch a fresh OAuth2 access token for a GOA account (by id). GOA refreshes the
 /// token as needed, so this always returns a currently-valid token. Blocking.
 pub fn oauth_token(goa_id: &str) -> Option<String> {
-    let conn = zbus::blocking::Connection::session().ok()?;
+    match try_oauth_token(goa_id) {
+        Ok(token) => Some(token),
+        Err(e) => {
+            tracing::warn!("GOA GetAccessToken failed for {goa_id}: {e}");
+            None
+        }
+    }
+}
+
+fn try_oauth_token(goa_id: &str) -> Result<String, String> {
+    let conn = zbus::blocking::Connection::session().map_err(|e| e.to_string())?;
     let path = format!("/org/gnome/OnlineAccounts/Accounts/{goa_id}");
     let reply = conn
         .call_method(
@@ -253,13 +263,14 @@ pub fn oauth_token(goa_id: &str) -> Option<String> {
             "GetAccessToken",
             &(),
         )
-        .ok()?;
+        .map_err(|e| e.to_string())?;
     // GetAccessToken() -> (access_token: s, expires_in: i)
-    let (token, _expires): (String, i32) = reply.body().deserialize().ok()?;
+    let (token, _expires): (String, i32) =
+        reply.body().deserialize().map_err(|e| e.to_string())?;
     if token.is_empty() {
-        None
+        Err("GOA returned an empty access token".to_string())
     } else {
-        Some(token)
+        Ok(token)
     }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -440,7 +440,7 @@ headerbar.rail-header button image {
   min-height: 8px;
   border-radius: 4px;
   background: @accent_bg_color;
-  margin-top: 6px;
+  margin: 0 2px;
 }
 
 .message-sender {

--- a/src/ui/message_list.rs
+++ b/src/ui/message_list.rs
@@ -520,7 +520,7 @@ impl MessageRow {
 }
 
 /// Sort messages in place by the chosen order (stable; ties fall back to date).
-fn sort_messages(msgs: &mut [Message], order: SortOrder) {
+fn message_cmp(a: &Message, b: &Message, order: SortOrder) -> std::cmp::Ordering {
     let name_of = |m: &Message| {
         if m.from_name.trim().is_empty() {
             m.from_addr.to_lowercase()
@@ -529,24 +529,20 @@ fn sort_messages(msgs: &mut [Message], order: SortOrder) {
         }
     };
     match order {
-        SortOrder::DateNewest => msgs.sort_by(|a, b| b.timestamp.cmp(&a.timestamp)),
-        SortOrder::DateOldest => msgs.sort_by(|a, b| a.timestamp.cmp(&b.timestamp)),
-        SortOrder::Sender => msgs.sort_by(|a, b| {
-            name_of(a).cmp(&name_of(b)).then(b.timestamp.cmp(&a.timestamp))
-        }),
-        SortOrder::Subject => msgs.sort_by(|a, b| {
-            normalize_subject(&a.subject)
-                .cmp(&normalize_subject(&b.subject))
-                .then(b.timestamp.cmp(&a.timestamp))
-        }),
+        SortOrder::DateNewest => b.timestamp.cmp(&a.timestamp),
+        SortOrder::DateOldest => a.timestamp.cmp(&b.timestamp),
+        SortOrder::Sender => name_of(a).cmp(&name_of(b)).then(b.timestamp.cmp(&a.timestamp)),
+        SortOrder::Subject => normalize_subject(&a.subject)
+            .cmp(&normalize_subject(&b.subject))
+            .then(b.timestamp.cmp(&a.timestamp)),
         // `true` sorts after `false`, so compare b-vs-a to put unread/flagged first.
-        SortOrder::UnreadFirst => {
-            msgs.sort_by(|a, b| b.unread.cmp(&a.unread).then(b.timestamp.cmp(&a.timestamp)))
-        }
-        SortOrder::FlaggedFirst => {
-            msgs.sort_by(|a, b| b.starred.cmp(&a.starred).then(b.timestamp.cmp(&a.timestamp)))
-        }
+        SortOrder::UnreadFirst => b.unread.cmp(&a.unread).then(b.timestamp.cmp(&a.timestamp)),
+        SortOrder::FlaggedFirst => b.starred.cmp(&a.starred).then(b.timestamp.cmp(&a.timestamp)),
     }
+}
+
+fn sort_message_refs(msgs: &mut [&Message], order: SortOrder) {
+    msgs.sort_by(|a, b| message_cmp(a, b, order));
 }
 
 /// The conversation key a message belongs to: its owning account plus the
@@ -1763,7 +1759,12 @@ impl MessageList {
 
     fn rebuild(&mut self) {
         let q = self.query.to_lowercase();
-        let mut matches: Vec<Message> = self
+        // Filter and sort by reference first — a folder's full index can hold
+        // hundreds of thousands of messages, and only `render_limit` of them are
+        // ever shown, so cloning the whole match set before capping it would
+        // block the UI thread on every rebuild (e.g. the initial cache-backed
+        // load on startup). Only the capped page gets cloned.
+        let mut matches: Vec<&Message> = self
             .active_source()
             .iter()
             .filter(|m| {
@@ -1773,13 +1774,14 @@ impl MessageList {
                     || m.from_addr.to_lowercase().contains(&q)
                     || m.preview.to_lowercase().contains(&q)
             })
-            .cloned()
             .collect();
-        sort_messages(&mut matches, self.sort);
-        self.total_matches = matches.len();
+        sort_message_refs(&mut matches, self.sort);
+        let total_matches = matches.len();
         // Render up to the current limit; the rest stay indexed (for search) until
         // the user scrolls further and `LoadMore` raises the limit.
-        let capped: Vec<Message> = matches.into_iter().take(self.render_limit).collect();
+        let render_limit = self.render_limit;
+        let capped: Vec<Message> = matches.into_iter().take(render_limit).cloned().collect();
+        self.total_matches = total_matches;
         self.rendered_count = capped.len();
 
         // Group into conversations by reply headers (Message-ID / In-Reply-To /

--- a/src/ui/message_list.rs
+++ b/src/ui/message_list.rs
@@ -153,13 +153,6 @@ impl FactoryComponent for MessageRow {
             },
 
             gtk::Box {
-                add_css_class: "unread-dot",
-                set_valign: gtk::Align::Center,
-                #[watch]
-                set_visible: self.msg.unread || self.thread_unread,
-            },
-
-            gtk::Box {
                 set_orientation: gtk::Orientation::Vertical,
                 set_spacing: 2,
                 set_hexpand: true,
@@ -185,6 +178,12 @@ impl FactoryComponent for MessageRow {
                         #[watch]
                         set_visible: self.msg.starred,
                         add_css_class: "star-icon",
+                    },
+                    gtk::Box {
+                        add_css_class: "unread-dot",
+                        set_valign: gtk::Align::Center,
+                        #[watch]
+                        set_visible: self.msg.unread || self.thread_unread,
                     },
                     gtk::Label {
                         set_label: &self.msg.datetime_list(),

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -21,6 +21,7 @@ pub struct PrefInit {
     pub threads_expanded: bool,
     pub message_theme: MessageTheme,
     pub notifications: bool,
+    pub show_attachments: bool,
 }
 
 /// Message-content appearance options, in combo order.
@@ -99,6 +100,7 @@ pub enum PrefInput {
     ChangeFetchInterval(u32),
     TogglePush(bool),
     ToggleNotifications(bool),
+    ToggleShowAttachments(bool),
     ChangePaletteCollapse(u64),
     ChangeMessageTheme(u32),
 }
@@ -115,6 +117,7 @@ pub enum PrefOutput {
     SetFetchInterval(u64),
     SetPush(bool),
     SetNotifications(bool),
+    SetShowAttachments(bool),
     SetPaletteCollapse(u64),
     SetMessageTheme(MessageTheme),
     Closed,
@@ -171,6 +174,15 @@ impl Component for Preferences {
                             set_subtitle: "Show system notifications for new mail and error alerts when Vireo isn't focused.",
                             connect_active_notify[sender] => move |row| {
                                 sender.input(PrefInput::ToggleNotifications(row.is_active()));
+                            },
+                        },
+
+                        #[name = "show_attachments_row"]
+                        adw::SwitchRow {
+                            set_title: "Attachments row",
+                            set_subtitle: "Show a sidebar shortcut for browsing every account's attachments.",
+                            connect_active_notify[sender] => move |row| {
+                                sender.input(PrefInput::ToggleShowAttachments(row.is_active()));
                             },
                         },
                     },
@@ -346,6 +358,7 @@ impl Component for Preferences {
         widgets.fetch_row.set_selected(selected as u32);
         widgets.push_row.set_active(init.push);
         widgets.notifications_row.set_active(init.notifications);
+        widgets.show_attachments_row.set_active(init.show_attachments);
         widgets.threading_row.set_active(init.threading);
         widgets.threads_expanded_row.set_active(init.threads_expanded);
 
@@ -391,6 +404,9 @@ impl Component for Preferences {
             }
             PrefInput::ToggleNotifications(on) => {
                 let _ = sender.output(PrefOutput::SetNotifications(on));
+            }
+            PrefInput::ToggleShowAttachments(on) => {
+                let _ = sender.output(PrefOutput::SetShowAttachments(on));
             }
             PrefInput::ChangePaletteCollapse(secs) => {
                 let _ = sender.output(PrefOutput::SetPaletteCollapse(secs));

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -38,6 +38,14 @@ pub struct SectionData {
     pub emoji: Option<String>,
 }
 
+/// Initial data for the sidebar.
+pub struct SidebarInit {
+    /// Icon-only mode: hide all text, show just icons and account pills.
+    pub collapsed: bool,
+    /// Whether to show the "Attachments" row.
+    pub show_attachments: bool,
+}
+
 /// What is currently selected in the sidebar.
 #[derive(Clone, PartialEq, Debug)]
 enum Sel {
@@ -75,6 +83,8 @@ pub struct Sidebar {
     selected: Sel,
     /// Icon-only mode: hide all text, show just icons and account pills.
     collapsed: bool,
+    /// Whether to show the "Attachments" row.
+    show_attachments: bool,
     /// Total unread across all inboxes, for the "All Inboxes" badge.
     unified_unread: u32,
     /// Unread badge labels by (account_id, folder_id), updated in place.
@@ -115,6 +125,8 @@ pub enum SidebarInput {
     /// Toggle the collapsible "Folders" (custom folders) section for an account.
     ToggleCustomFoldersLocal(u32),
     ToggleCollapsed,
+    /// Show or hide the "Attachments" row.
+    SetShowAttachments(bool),
     /// Update unread badges in place without rebuilding the sidebar.
     SetUnread {
         folders: HashMap<(u32, u32), u32>,
@@ -173,7 +185,7 @@ pub enum CtxAction {
 
 #[relm4::component(pub)]
 impl Component for Sidebar {
-    type Init = bool;
+    type Init = SidebarInit;
     type Input = SidebarInput;
     type Output = SidebarOutput;
     type CommandOutput = ();
@@ -235,7 +247,8 @@ impl Component for Sidebar {
             attachments_list: None,
             color_provider,
             selected: Sel::None,
-            collapsed: init,
+            collapsed: init.collapsed,
+            show_attachments: init.show_attachments,
             unified_unread: 0,
             folder_badges: HashMap::new(),
             unified_badge: None,
@@ -249,7 +262,7 @@ impl Component for Sidebar {
         };
 
         let widgets = view_output!();
-        if init {
+        if init.collapsed {
             widgets.collapse_btn.set_icon_name("co.hyprlab.Vireo-go-next-symbolic");
             widgets.collapse_btn.set_tooltip_text(Some("Expand sidebar"));
         }
@@ -408,6 +421,17 @@ impl Component for Sidebar {
                 self.rebuild_normal(&widgets.normal_box, &sender);
                 self.restore_selection();
                 let _ = sender.output(SidebarOutput::CollapsedChanged(self.collapsed));
+            }
+
+            SidebarInput::SetShowAttachments(on) => {
+                self.show_attachments = on;
+                // The row is about to disappear out from under the current
+                // selection — fall back the same way an empty selection does.
+                if !on && self.selected == Sel::Attachments {
+                    self.selected = Sel::None;
+                }
+                self.rebuild_normal(&widgets.normal_box, &sender);
+                self.restore_selection();
             }
 
             SidebarInput::ToggleCollapseLocal(id) => {
@@ -750,7 +774,7 @@ impl Sidebar {
 
         // "Attachments" row — a gallery of every inbox attachment. Sits under the
         // All Inboxes block and above the per-account sections.
-        {
+        if self.show_attachments {
             let list = gtk::ListBox::new();
             list.set_selection_mode(gtk::SelectionMode::Single);
             list.add_css_class("navigation-sidebar");

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -394,12 +394,26 @@ async fn run_imap(
                 } else if !backfill.is_empty() {
                     // Index the rest of the mailbox in the background. Connect first
                     // for cached-folder accounts (which connect lazily); if still
-                    // offline, wait for a request instead of spinning.
+                    // offline, wait for a request instead of spinning. An incoming
+                    // request (e.g. the initial cache-backed folder load on startup)
+                    // preempts this connect so cached mail isn't stuck behind a slow
+                    // IMAP handshake before it's even looked at.
                     if session.is_none() {
-                        session =
-                            connect_and_list(account_id, &account, cache.as_ref(), &emit).await;
-                    }
-                    if session.is_some() {
+                        let connect = connect_and_list(account_id, &account, cache.as_ref(), &emit);
+                        tokio::select! {
+                            biased;
+                            req = rx.recv() => {
+                                match req {
+                                    Some(req) => req,
+                                    None => break,
+                                }
+                            }
+                            s = connect => {
+                                session = s;
+                                continue;
+                            }
+                        }
+                    } else {
                         run_one_backfill(
                             &mut backfill,
                             &mut session,
@@ -412,11 +426,6 @@ async fn run_imap(
                         )
                         .await;
                         continue;
-                    } else {
-                        match rx.recv().await {
-                            Some(req) => req,
-                            None => break,
-                        }
                     }
                 } else if push_enabled && session.is_some() && idle_folder.is_some() {
                     let (fid, fpath) = idle_folder.clone().unwrap();

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -17,7 +17,9 @@ use chrono::Datelike;
 use futures::TryStreamExt;
 use lettre::message::Mailbox;
 use lettre::transport::smtp::authentication::Credentials;
-use lettre::{AsyncSmtpTransport, AsyncTransport, Message as LettreMessage, Tokio1Executor};
+use lettre::{
+    Address, AsyncSmtpTransport, AsyncTransport, Message as LettreMessage, Tokio1Executor,
+};
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 
@@ -1550,16 +1552,39 @@ fn parse_recipients(s: &str) -> Vec<(String, String)> {
 /// Build the RFC 822 email (headers + MIME body) from a composed message. Shared
 /// by SMTP sending and by saving to Drafts (no network).
 fn build_email(account: &AccountConfig, msg: &OutgoingMessage) -> Result<LettreMessage, SmtpError> {
-    let from: Mailbox = format!("{} <{}>", account.name, account.email).parse()?;
+    let email: Address = account
+        .email
+        .parse()
+        .map_err(|e| format!("invalid account email {:?}: {e}", account.email))?;
+    // Build the mailbox from its parts rather than formatting "Name <email>" and
+    // parsing that as one string: an unquoted RFC 5322 display name can't contain
+    // '@' or '.', so an account whose name happens to equal its own address (e.g.
+    // a GOA import with no separate display name) would fail to parse. Mailbox::new
+    // quotes the name correctly at encode time instead, for any name.
+    let name = account.name.trim();
+    let from = if name.is_empty() || name.eq_ignore_ascii_case(&account.email) {
+        Mailbox::new(None, email)
+    } else {
+        Mailbox::new(Some(name.to_string()), email)
+    };
     let mut builder = LettreMessage::builder().from(from);
     for addr in split_addrs(&msg.to) {
-        builder = builder.to(addr.parse()?);
+        let mailbox = addr
+            .parse()
+            .map_err(|e| format!("invalid To address {addr:?}: {e}"))?;
+        builder = builder.to(mailbox);
     }
     for addr in split_addrs(&msg.cc) {
-        builder = builder.cc(addr.parse()?);
+        let mailbox = addr
+            .parse()
+            .map_err(|e| format!("invalid Cc address {addr:?}: {e}"))?;
+        builder = builder.cc(mailbox);
     }
     for addr in split_addrs(&msg.bcc) {
-        builder = builder.bcc(addr.parse()?);
+        let mailbox = addr
+            .parse()
+            .map_err(|e| format!("invalid Bcc address {addr:?}: {e}"))?;
+        builder = builder.bcc(mailbox);
     }
     let builder = builder.subject(msg.subject.clone());
 
@@ -1585,7 +1610,8 @@ fn build_email(account: &AccountConfig, msg: &OutgoingMessage) -> Result<LettreM
             MultiPart::mixed().singlepart(SinglePart::plain(msg.body.clone()))
         };
         for path in &msg.attachments {
-            let bytes = std::fs::read(path)?;
+            let bytes = std::fs::read(path)
+                .map_err(|e| format!("could not read attachment {path:?}: {e}"))?;
             let name = std::path::Path::new(path)
                 .file_name()
                 .map(|s| s.to_string_lossy().to_string())
@@ -1606,10 +1632,11 @@ async fn send_smtp(account: &AccountConfig, msg: &OutgoingMessage) -> Result<Vec
     let host = smtp_host(account);
     // Port 465 is implicit TLS; everything else (587, etc.) uses STARTTLS.
     let transport_builder = if account.smtp_port == 465 {
-        AsyncSmtpTransport::<Tokio1Executor>::relay(&host)?
+        AsyncSmtpTransport::<Tokio1Executor>::relay(&host)
     } else {
-        AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&host)?
-    };
+        AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&host)
+    }
+    .map_err(|e| format!("could not set up SMTP transport for {host}:{}: {e}", account.smtp_port))?;
     let mut builder = transport_builder.port(account.smtp_port);
     if account.oauth {
         // XOAUTH2: the "password" is a fresh OAuth token from GOA.
@@ -1631,7 +1658,10 @@ async fn send_smtp(account: &AccountConfig, msg: &OutgoingMessage) -> Result<Vec
     }
     let mailer: AsyncSmtpTransport<Tokio1Executor> = builder.build();
 
-    mailer.send(email).await?;
+    mailer
+        .send(email)
+        .await
+        .map_err(|e| format!("SMTP server {host}:{} rejected the message: {e}", account.smtp_port))?;
     Ok(raw)
 }
 


### PR DESCRIPTION
Hello there!

While using this email client I noticed a couple of visual bugs:
- Unread dot moving all the message title and content to the right unnecessarily
- Empty email list on startup even though account had been sync'd before

I also added a couple of nice-to-haves, like:
- "Mark as Unread" button in the email detail view
- Show/hide attachments toggle in settings (I didn't like it being at the top, felt like it was unnecessary visual priority)

But more importantly, found a bug while sending email:
- It tried to use the full name (e.g. "Alfonso Lizarraga <alfonso.lzrg@gmail>") as `To:`. When the name wasn't available, it defaulted to the same email twice (e.g. "alfonso.lzrg@gmail.com <alfonso.lzrg@gmail.com>") which failed at sending with an "Invalid param" error.

I used Claude to figure out and fix these bugs. I couldn't find a CONTRIBUTORS file, so I'm sending these fixes upstream like this. Let me know if you'd like me to proceed in a different way!