### PR TITLE
Add option to always load remote content

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -179,6 +179,8 @@ pub struct AppModel {
     current: Option<Message>,
     /// Sender addresses allowed to auto-load remote content (lowercased).
     allowed_senders: Vec<String>,
+    /// Whether remote content is auto-loaded for every new message.
+    auto_remote_content: bool,
     /// Addresses/domains whose incoming inbox mail is auto-deleted (lowercased).
     blacklist: Vec<String>,
     /// Seconds the message-list Actions Palette stays open after the cursor leaves.
@@ -342,6 +344,7 @@ pub enum AppMsg {
     AddBlacklist(String),
     RemoveBlacklist(String),
     MarkSpam,
+    SetAutoRemoteContent(bool),
     SetGravatar(bool),
     SetAvatars(bool),
     SetSenderLogos(bool),
@@ -1055,6 +1058,7 @@ impl SimpleComponent for AppModel {
             sidebar_anim: None,
             current: None,
             allowed_senders: config::load_allowed_senders(),
+            auto_remote_content: config::load_auto_remote_content(),
             blacklist: config::load_blacklist(),
             palette_collapse_secs: config::load_palette_collapse(),
             gravatar: config::load_gravatar(),
@@ -2127,6 +2131,12 @@ impl SimpleComponent for AppModel {
                     for p in self.popouts.values() {
                         p.controller.emit(MessageWindowInput::SetSenderLogos(on));
                     }
+            
+            AppMsg::SetAutoRemoteContent(on) => {
+                if self.auto_remote_content != on {
+                    self.auto_remote_content = on;
+                    self.save_settings();
+                    // Re-evaluate remote-content blocking for the open message.
                     let current = self.current.clone();
                     self.show_message(current, false);
                 }
@@ -2517,6 +2527,7 @@ impl SimpleComponent for AppModel {
                 }
                 let init = PrefInit {
                     allowed_senders: self.allowed_senders.clone(),
+                    auto_remote_content: self.auto_remote_content,
                     gravatar: self.gravatar,
                     avatars: self.avatars,
                     sender_logos: self.sender_logos,
@@ -2544,6 +2555,7 @@ impl SimpleComponent for AppModel {
                         PrefOutput::RemoveSender(addr) => AppMsg::RemoveSender(addr),
                         PrefOutput::AddBlacklist(addr) => AppMsg::AddBlacklist(addr),
                         PrefOutput::RemoveBlacklist(addr) => AppMsg::RemoveBlacklist(addr),
+                        PrefOutput::SetAutoRemoteContent(on) => AppMsg::SetAutoRemoteContent(on),
                         PrefOutput::SetGravatar(on) => AppMsg::SetGravatar(on),
                         PrefOutput::SetAvatars(on) => AppMsg::SetAvatars(on),
                         PrefOutput::SetSenderLogos(on) => AppMsg::SetSenderLogos(on),
@@ -2962,6 +2974,7 @@ impl AppModel {
     fn save_settings(&self) {
         config::save_privacy(
             &self.allowed_senders,
+            self.auto_remote_content,
             self.gravatar,
             self.avatars,
             self.sender_logos,
@@ -3491,6 +3504,9 @@ impl AppModel {
     }
 
     fn remote_allowed(&self, m: &Message) -> bool {
+        if self.auto_remote_content {
+            return true;
+        }
         let addr = m.from_addr.to_lowercase();
         self.allowed_senders.iter().any(|s| *s == addr)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -363,6 +363,11 @@ pub enum ClockStyle {
 struct PrivacyFile {
     #[serde(default)]
     allowed_senders: Vec<String>,
+    /// Whether remote content (images, trackers) is auto-loaded for every new
+    /// message, not just those from allowed senders. Off by default, since
+    /// remote content can be used to track when and where a message is read.
+    #[serde(default)]
+    auto_remote_content: bool,
     /// Whether to load sender avatars from Gravatar (off by default — it sends
     /// a hash of each sender's email to a third party).
     #[serde(default)]
@@ -465,6 +470,7 @@ impl Default for PrivacyFile {
     fn default() -> Self {
         Self {
             allowed_senders: Vec::new(),
+            auto_remote_content: false,
             gravatar: false,
             avatars: default_avatars(),
             sender_logos: false,
@@ -504,6 +510,11 @@ fn load_privacy() -> PrivacyFile {
 /// Senders whose messages may auto-load remote content. Stored lowercased.
 pub fn load_allowed_senders() -> Vec<String> {
     load_privacy().allowed_senders
+}
+
+/// Whether remote content is auto-loaded for every new message.
+pub fn load_auto_remote_content() -> bool {
+    load_privacy().auto_remote_content
 }
 
 /// Whether Gravatar avatar loading is enabled.
@@ -598,6 +609,7 @@ pub fn load_autostart() -> bool {
 #[allow(clippy::too_many_arguments)]
 pub fn save_privacy(
     senders: &[String],
+    auto_remote_content: bool,
     gravatar: bool,
     avatars: bool,
     sender_logos: bool,
@@ -625,6 +637,7 @@ pub fn save_privacy(
     }
     let file = PrivacyFile {
         allowed_senders: senders.to_vec(),
+        auto_remote_content,
         gravatar,
         avatars,
         sender_logos,

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -12,6 +12,7 @@ use crate::config::{ClockStyle, DateStyle, MessageTheme};
 #[derive(Debug)]
 pub struct PrefInit {
     pub allowed_senders: Vec<String>,
+    pub auto_remote_content: bool,
     pub gravatar: bool,
     pub avatars: bool,
     pub sender_logos: bool,
@@ -117,6 +118,7 @@ pub enum PrefInput {
     RemoveSenderRow(String),
     AddBlacklistText(String),
     RemoveBlacklistRow(String),
+    ToggleAutoRemoteContent(bool),
     ToggleGravatar(bool),
     ToggleAvatars(bool),
     ToggleSenderLogos(bool),
@@ -142,6 +144,7 @@ pub enum PrefOutput {
     RemoveSender(String),
     AddBlacklist(String),
     RemoveBlacklist(String),
+    SetAutoRemoteContent(bool),
     SetGravatar(bool),
     SetAvatars(bool),
     SetSenderLogos(bool),
@@ -353,9 +356,22 @@ impl Component for Preferences {
                         set_title: "Privacy",
                         set_description: Some(
                             "Vireo collects no telemetry and sends no analytics. Remote \
-                             content (images, trackers) is blocked by default; you can allow \
-                             it per message, or trust a sender to always load it."
+                             content (images, trackers) is blocked by default. Allow it per \
+                             message, trust a sender to always load it, or turn on \"Load \
+                             remote content automatically\" below to always load it."
                         ),
+
+                        #[name = "auto_remote_content_row"]
+                        adw::SwitchRow {
+                            set_title: "Load remote content automatically",
+                            set_subtitle: "Show images and other remote content in every new \
+                                           message without asking. Off by default, since \
+                                           remote content can be used to track when and where \
+                                           you read a message.",
+                            connect_active_notify[sender] => move |row| {
+                                sender.input(PrefInput::ToggleAutoRemoteContent(row.is_active()));
+                            },
+                        },
 
                         #[name = "gravatar_row"]
                         adw::SwitchRow {
@@ -474,6 +490,7 @@ impl Component for Preferences {
         let senders_box = model.senders.widget();
         let blacklist_box = model.blacklist.widget();
         let widgets = view_output!();
+        widgets.auto_remote_content_row.set_active(init.auto_remote_content);
         widgets.gravatar_row.set_active(init.gravatar);
         widgets.avatars_row.set_active(init.avatars);
         widgets.sender_logos_row.set_active(init.sender_logos);
@@ -570,6 +587,9 @@ impl Component for Preferences {
             }
             PrefInput::ToggleGravatar(on) => {
                 let _ = sender.output(PrefOutput::SetGravatar(on));
+            }
+            PrefInput::ToggleAutoRemoteContent(on) => {
+                let _ = sender.output(PrefOutput::SetAutoRemoteContent(on));
             }
             PrefInput::ToggleThreading(on) => {
                 let _ = sender.output(PrefOutput::SetThreading(on));

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -357,13 +357,13 @@ impl Component for Preferences {
                         set_description: Some(
                             "Vireo collects no telemetry and sends no analytics. Remote \
                              content (images, trackers) is blocked by default. Allow it per \
-                             message, trust a sender to always load it, or turn on \"Load \
-                             remote content automatically\" below to always load it."
+                             message, trust a sender to always load it, or turn on \"Always \
+                             load remote content\" below."
                         ),
 
                         #[name = "auto_remote_content_row"]
                         adw::SwitchRow {
-                            set_title: "Load remote content automatically",
+                            set_title: "Always load remote content",
                             set_subtitle: "Show images and other remote content in every new \
                                            message without asking. Off by default, since \
                                            remote content can be used to track when and where \


### PR DESCRIPTION
While I understand the reasoning behind the original design, one feature I'm missing from Vireo is the ability to always load remote content and images for every message. This patch creates a new option in preferences to load remote content automatically. If enabled, all remote content loads. If not, the original behavior (per message or per sender) is still intact. Obviously, this option is off by default.

<img width="550" height="670" alt="Screenshot From 2026-08-23 01-05-15" src="https://github.com/user-attachments/assets/64e0d3d7-f881-4712-9d2d-a5adeb4ad5f0" />

