### PR TITLE
Gmail conversations: one message per thread, and one fetch for its bodies

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -6234,6 +6234,21 @@ type MissingBody = (u32, u32, u32, String);
 /// One `LoadBodies` request: the `(account_id, folder_path)` it goes to, and the
 /// `(message_id, uid)` of every member it covers.
 type BodyBatch = ((u32, String), Vec<(u32, u32)>);
+
+/// Whether two rows are the same mail stored twice, rather than two messages.
+///
+/// Message-ID is the identity, but it is written by whoever sent the mail and
+/// spam reuses one across unrelated messages — so sender and timestamp have to
+/// agree as well before one copy is allowed to stand for another. Gmail's label
+/// copies agree on all three. Subject is deliberately left out: a re-decoded
+/// encoded-word can rewrite it under one label and not another.
+fn same_mail(a: &Message, b: &Message) -> bool {
+    !a.message_id.is_empty()
+        && a.message_id == b.message_id
+        && a.from_addr == b.from_addr
+        && a.timestamp == b.timestamp
+}
+
 /// Keep one copy of each message, dropping the rest of its labels.
 ///
 /// Gmail exposes labels as IMAP folders, so a single message sits in INBOX,
@@ -6253,10 +6268,10 @@ fn dedupe_label_copies(messages: Vec<Message>, conv: &[Message], shown_folder: u
             out.push(r);
             continue;
         }
-        if conv.iter().any(|m| m.message_id == r.message_id) {
+        if conv.iter().any(|m| same_mail(m, &r)) {
             continue; // the conversation already holds this mail under some label
         }
-        match out.iter().position(|m| m.message_id == r.message_id) {
+        match out.iter().position(|m| same_mail(m, &r)) {
             Some(i) => {
                 if out[i].folder_id != shown_folder && r.folder_id == shown_folder {
                     out[i] = r;
@@ -6363,6 +6378,17 @@ mod tests {
         let conv = vec![labelled(1, 42, "<a@example.com>")];
         let kept = dedupe_label_copies(vec![labelled(2, 500, "<a@example.com>")], &conv, 1);
         assert!(kept.is_empty(), "the conversation already holds this mail");
+    }
+
+    #[test]
+    fn a_reused_message_id_is_not_treated_as_the_same_mail() {
+        let mut spam = labelled(2, 900, "<a@example.com>");
+        spam.from_addr = "spammer@fake.example".into();
+        let mut mine = labelled(1, 42, "<a@example.com>");
+        mine.from_addr = "me@real.example".into();
+
+        let kept = dedupe_label_copies(vec![mine, spam], &[], 1);
+        assert_eq!(kept.len(), 2, "a shared id from another sender is other mail");
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1859,7 +1859,7 @@ impl SimpleComponent for AppModel {
                     }
                     self.current_thread = conv;
                     // Fetch the bodies we don't have yet (primary first via order).
-                    let to_load: Vec<(u32, u32, u32, String)> = self
+                    let to_load: Vec<MissingBody> = self
                         .current_thread
                         .iter()
                         .filter(|tm| tm.body.is_empty())
@@ -1868,8 +1868,8 @@ impl SimpleComponent for AppModel {
                                 .map(|p| (tm.account_id, tm.id, tm.uid, p))
                         })
                         .collect();
-                    for (aid, mid, uid, path) in to_load {
-                        self.send_to(aid, MailRequest::LoadBody { message_id: mid, path, uid });
+                    for ((aid, path), items) in batch_bodies_by_folder(to_load) {
+                        self.send_to(aid, MailRequest::LoadBodies { items, path });
                     }
                     self.show_thread();
                 } else {
@@ -6226,6 +6226,36 @@ fn build_search_pool(cache: &HashMap<(u32, u32), Vec<Message>>) -> Vec<Message> 
     cache.values().flatten().cloned().collect()
 }
 
+/// A conversation member still waiting for its body:
+/// `(account_id, message_id, uid, folder_path)`.
+type MissingBody = (u32, u32, u32, String);
+
+/// One `LoadBodies` request: the `(account_id, folder_path)` it goes to, and the
+/// `(message_id, uid)` of every member it covers.
+type BodyBatch = ((u32, String), Vec<(u32, u32)>);
+
+/// Group a conversation's missing bodies into one request per (account, folder).
+///
+/// Every member asked for on its own is a round trip each, and each arrival
+/// re-renders the reader; `LoadBodies` fetches a whole UID set at once. Members
+/// are kept in the order given — the primary is first, so it is first in its
+/// batch and renders first — and a conversation that spans folders (or, in the
+/// unified inbox, accounts) splits into one batch per folder rather than losing
+/// the members that don't fit the first one.
+fn batch_bodies_by_folder(to_load: Vec<MissingBody>) -> Vec<BodyBatch> {
+    let mut batches: Vec<BodyBatch> = Vec::new();
+    for (account_id, message_id, uid, path) in to_load {
+        match batches
+            .iter_mut()
+            .find(|((a, p), _)| *a == account_id && *p == path)
+        {
+            Some((_, items)) => items.push((message_id, uid)),
+            None => batches.push(((account_id, path), vec![(message_id, uid)])),
+        }
+    }
+    batches
+}
+
 /// Where to move the reader when its message disappeared from a sync (deleted or
 /// moved on another device): whatever now sits in the slot it occupied.
 ///
@@ -6248,6 +6278,38 @@ fn next_after_vanish(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_conversation_in_one_folder_becomes_a_single_fetch() {
+        let batches = batch_bodies_by_folder(vec![
+            (1, 10, 100, "INBOX".into()),
+            (1, 11, 101, "INBOX".into()),
+            (1, 12, 102, "INBOX".into()),
+        ]);
+        assert_eq!(batches.len(), 1, "one folder is one round trip");
+        assert_eq!(batches[0].0, (1, "INBOX".to_string()));
+        // Order is the thread's, so the primary is fetched and rendered first.
+        assert_eq!(batches[0].1, vec![(10, 100), (11, 101), (12, 102)]);
+    }
+
+    #[test]
+    fn members_from_other_folders_and_accounts_get_their_own_fetch() {
+        // A conversation pulled together across Inbox and Sent, plus a second
+        // account: batching must not drop the members that don't share the
+        // first one's folder.
+        let batches = batch_bodies_by_folder(vec![
+            (1, 10, 100, "INBOX".into()),
+            (1, 11, 55, "Sent".into()),
+            (1, 12, 101, "INBOX".into()),
+            (2, 13, 7, "INBOX".into()),
+        ]);
+        assert_eq!(batches.len(), 3);
+        assert_eq!(batches[0], ((1, "INBOX".to_string()), vec![(10, 100), (12, 101)]));
+        assert_eq!(batches[1], ((1, "Sent".to_string()), vec![(11, 55)]));
+        assert_eq!(batches[2], ((2, "INBOX".to_string()), vec![(13, 7)]));
+        let members: usize = batches.iter().map(|(_, items)| items.len()).sum();
+        assert_eq!(members, 4, "every member is still requested");
+    }
 
     #[test]
     fn a_vanished_message_never_throws_you_to_the_top() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -4450,6 +4450,7 @@ impl AppModel {
         } else {
             self.current_thread.clone()
         };
+        let messages = dedupe_label_copies(messages, &conv, current.folder_id);
         let mut added = Vec::new();
         for mut r in messages {
             if conv.iter().any(|m| m.folder_id == r.folder_id && m.uid == r.uid) {
@@ -6233,6 +6234,39 @@ type MissingBody = (u32, u32, u32, String);
 /// One `LoadBodies` request: the `(account_id, folder_path)` it goes to, and the
 /// `(message_id, uid)` of every member it covers.
 type BodyBatch = ((u32, String), Vec<(u32, u32)>);
+/// Keep one copy of each message, dropping the rest of its labels.
+///
+/// Gmail exposes labels as IMAP folders, so a single message sits in INBOX,
+/// All Mail and Important at once — three folder/UID pairs carrying one
+/// Message-ID. A conversation that dedupes on those pairs alone therefore shows
+/// every copy: a six-message thread renders as eighteen. On a real cache 1210 of
+/// this account's 1212 messages are labelled that way, so this is the normal
+/// case for Gmail, not an edge one.
+///
+/// The copy from the folder the reader is showing wins, so the "from folder X"
+/// label and the actions on a message refer to the mail actually on screen. A
+/// message with no Message-ID can't be matched this way and is left alone.
+fn dedupe_label_copies(messages: Vec<Message>, conv: &[Message], shown_folder: u32) -> Vec<Message> {
+    let mut out: Vec<Message> = Vec::new();
+    for r in messages {
+        if r.message_id.is_empty() {
+            out.push(r);
+            continue;
+        }
+        if conv.iter().any(|m| m.message_id == r.message_id) {
+            continue; // the conversation already holds this mail under some label
+        }
+        match out.iter().position(|m| m.message_id == r.message_id) {
+            Some(i) => {
+                if out[i].folder_id != shown_folder && r.folder_id == shown_folder {
+                    out[i] = r;
+                }
+            }
+            None => out.push(r),
+        }
+    }
+    out
+}
 
 /// Group a conversation's missing bodies into one request per (account, folder).
 ///
@@ -6278,6 +6312,66 @@ fn next_after_vanish(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A conversation member as the related-lookup hands it over: what matters
+    /// here is which folder it came from and what Message-ID it carries.
+    fn labelled(folder_id: u32, uid: u32, message_id: &str) -> Message {
+        Message {
+            id: uid,
+            account_id: 1,
+            folder_id,
+            uid,
+            from_name: String::new(),
+            from_addr: String::new(),
+            to: String::new(),
+            cc: String::new(),
+            subject: String::new(),
+            preview: String::new(),
+            body: String::new(),
+            date: String::new(),
+            timestamp: 0,
+            unread: false,
+            starred: false,
+            has_attachment: false,
+            message_id: message_id.to_string(),
+            references: String::new(),
+        }
+    }
+
+    #[test]
+    fn one_gmail_message_under_three_labels_joins_the_conversation_once() {
+        // INBOX = 1, All Mail = 2, Important = 3 — the same mail in all three,
+        // which is how 1210 of one real account's 1212 messages are stored.
+        let related = vec![
+            labelled(2, 500, "<a@example.com>"),
+            labelled(3, 900, "<a@example.com>"),
+            labelled(1, 42, "<a@example.com>"),
+            labelled(2, 501, "<b@example.com>"),
+        ];
+        let kept = dedupe_label_copies(related, &[], 1);
+        assert_eq!(kept.len(), 2, "two messages, not four copies");
+        let a = kept.iter().find(|m| m.message_id == "<a@example.com>").unwrap();
+        assert_eq!(
+            (a.folder_id, a.uid),
+            (1, 42),
+            "the copy from the folder on screen wins, whatever order it arrived in"
+        );
+    }
+
+    #[test]
+    fn a_label_copy_of_a_message_already_shown_is_dropped() {
+        let conv = vec![labelled(1, 42, "<a@example.com>")];
+        let kept = dedupe_label_copies(vec![labelled(2, 500, "<a@example.com>")], &conv, 1);
+        assert!(kept.is_empty(), "the conversation already holds this mail");
+    }
+
+    #[test]
+    fn messages_without_a_message_id_are_never_merged_together() {
+        // Two distinct messages that carry no Message-ID must stay two: there is
+        // nothing to match them on, and folding them would lose one.
+        let kept = dedupe_label_copies(vec![labelled(1, 7, ""), labelled(1, 8, "")], &[], 1);
+        assert_eq!(kept.len(), 2);
+    }
 
     #[test]
     fn a_conversation_in_one_folder_becomes_a_single_fetch() {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -562,6 +562,14 @@ impl Cache {
     }
 
     pub fn load_body(&self, account_id: u32, folder_path: &str, uid: u32) -> Option<String> {
+        self.body_of(account_id, folder_path, uid).or_else(|| {
+            self.sibling_copies(account_id, folder_path, uid)
+                .into_iter()
+                .find_map(|(p, u)| self.body_of(account_id, &p, u))
+        })
+    }
+
+    fn body_of(&self, account_id: u32, folder_path: &str, uid: u32) -> Option<String> {
         self.conn
             .query_row(
                 "SELECT body FROM bodies WHERE account_id = ?1 AND folder_path = ?2 AND uid = ?3",
@@ -569,6 +577,36 @@ impl Cache {
                 |row| row.get::<_, String>(0),
             )
             .ok()
+    }
+
+    /// Every other copy of this message in the account, as `(folder_path, uid)`.
+    ///
+    /// Gmail exposes labels as IMAP folders, so one message is stored several
+    /// times over — INBOX, All Mail, Important — under a different UID in each.
+    /// Everything keyed by (folder, uid) is therefore per-*copy*: a body read
+    /// while the user was in All Mail is invisible to the INBOX copy, and its
+    /// attachments would be downloaded a second time. They are the same mail, so
+    /// a miss on one copy is answered from another instead of from the network.
+    /// On a real cache 176 messages have a body under only some of their labels,
+    /// and 31 have their attachments downloaded under only some.
+    fn sibling_copies(&self, account_id: u32, folder_path: &str, uid: u32) -> Vec<(String, u32)> {
+        let run = || -> rusqlite::Result<Vec<(String, u32)>> {
+            let mut stmt = self.conn.prepare(
+                "SELECT folder_path, uid FROM messages \
+                 WHERE account_id = ?1 AND message_id != '' \
+                   AND message_id = (SELECT message_id FROM messages \
+                                     WHERE account_id = ?1 AND folder_path = ?2 AND uid = ?3) \
+                   AND NOT (folder_path = ?2 AND uid = ?3)",
+            )?;
+            let rows = stmt.query_map(params![account_id, folder_path, uid], |row| {
+                Ok((row.get(0)?, row.get(1)?))
+            })?;
+            rows.collect()
+        };
+        run().unwrap_or_else(|e| {
+            tracing::warn!("cache sibling_copies failed: {e}");
+            Vec::new()
+        })
     }
 
     pub fn save_body(&self, account_id: u32, folder_path: &str, uid: u32, body: &str) {
@@ -583,6 +621,19 @@ impl Cache {
     /// The cached sender-authentication verdict for a message, if one was stored
     /// when its body was fetched.
     pub fn load_sender_check(
+        &self,
+        account_id: u32,
+        folder_path: &str,
+        uid: u32,
+    ) -> Option<crate::models::SenderCheck> {
+        self.sender_check_of(account_id, folder_path, uid).or_else(|| {
+            self.sibling_copies(account_id, folder_path, uid)
+                .into_iter()
+                .find_map(|(p, u)| self.sender_check_of(account_id, &p, u))
+        })
+    }
+
+    fn sender_check_of(
         &self,
         account_id: u32,
         folder_path: &str,
@@ -687,6 +738,20 @@ impl Cache {
     }
 
     pub fn load_attachments(&self, account_id: u32, folder_path: &str, uid: u32) -> Vec<Attachment> {
+        let own = self.attachments_of(account_id, folder_path, uid);
+        if !own.is_empty() {
+            return own;
+        }
+        // Downloaded under another of this message's labels: same mail, same
+        // attachments, no reason to fetch them again.
+        self.sibling_copies(account_id, folder_path, uid)
+            .into_iter()
+            .map(|(p, u)| self.attachments_of(account_id, &p, u))
+            .find(|items| !items.is_empty())
+            .unwrap_or_default()
+    }
+
+    fn attachments_of(&self, account_id: u32, folder_path: &str, uid: u32) -> Vec<Attachment> {
         let run = || -> rusqlite::Result<Vec<Attachment>> {
             let mut stmt = self.conn.prepare(
                 "SELECT name, data FROM attachments
@@ -1253,6 +1318,63 @@ mod tests {
         let found = c.messages_by_thread_ids(1, &["root@x".to_string()], 0);
         let ids: Vec<&str> = found.iter().map(|(_, m)| m.message_id.as_str()).collect();
         assert_eq!(ids, vec!["reply@x", "root@x"], "only the real conversation");
+    }
+
+    /// Gmail stores one message under every label it carries, so INBOX, All Mail
+    /// and Important hold three copies with three UIDs. A body read under one
+    /// label has to answer for the others, or opening the conversation from the
+    /// Inbox re-downloads mail already in hand — and its attachments come back
+    /// as a "Load attachments" button rather than the files themselves.
+    #[test]
+    fn a_body_cached_under_one_gmail_label_answers_for_the_others() {
+        let c = Cache::in_memory();
+        add_threaded(&c, "INBOX", 42, 500, "same@x", "");
+        add_threaded(&c, "[Gmail]/All Mail", 900, 500, "same@x", "");
+        c.save_body(1, "[Gmail]/All Mail", 900, "the real body");
+
+        assert_eq!(c.load_body(1, "INBOX", 42).as_deref(), Some("the real body"));
+        // The copy that actually holds it still answers directly.
+        assert_eq!(
+            c.load_body(1, "[Gmail]/All Mail", 900).as_deref(),
+            Some("the real body")
+        );
+    }
+
+    #[test]
+    fn attachments_downloaded_under_one_label_answer_for_the_others() {
+        let c = Cache::in_memory();
+        add_threaded(&c, "INBOX", 42, 500, "same@x", "");
+        add_threaded(&c, "Paratype", 7, 500, "same@x", "");
+        c.save_attachments(
+            1,
+            "Paratype",
+            7,
+            &[Attachment { name: "spec.pdf".into(), data: vec![1, 2, 3] }],
+        );
+
+        let found = c.load_attachments(1, "INBOX", 42);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].name, "spec.pdf");
+    }
+
+    /// Two different messages must never answer for each other — the fallback
+    /// keys on Message-ID, and a message that has none has nothing to match.
+    #[test]
+    fn a_different_message_never_answers_for_this_one() {
+        let c = Cache::in_memory();
+        add_threaded(&c, "INBOX", 42, 500, "mine@x", "");
+        add_threaded(&c, "[Gmail]/All Mail", 900, 500, "someone-else@x", "");
+        c.save_body(1, "[Gmail]/All Mail", 900, "not yours");
+        assert_eq!(c.load_body(1, "INBOX", 42), None);
+
+        add_threaded(&c, "INBOX", 43, 500, "", "");
+        add_threaded(&c, "Archive", 44, 500, "", "");
+        c.save_body(1, "Archive", 44, "unrelated");
+        assert_eq!(
+            c.load_body(1, "INBOX", 43),
+            None,
+            "an empty Message-ID matches nothing, not everything"
+        );
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -589,14 +589,27 @@ impl Cache {
     /// a miss on one copy is answered from another instead of from the network.
     /// On a real cache 176 messages have a body under only some of their labels,
     /// and 31 have their attachments downloaded under only some.
+    ///
+    /// Copies must agree on sender and timestamp as well as Message-ID. The id is
+    /// supposed to be unique, but it is written by whoever sent the mail, and
+    /// spam and some list software reuse one across genuinely different messages
+    /// — where serving one message's body for another would be worse than the
+    /// cache miss this avoids. Gmail's own copies agree on all three (verified
+    /// across a real 8300-message cache: no Message-ID there covers two
+    /// different senders, subjects or timestamps), so the fallback still fires
+    /// where it was meant to. Subject is deliberately not compared: a re-decoded
+    /// encoded-word can rewrite it under one label and not another.
     fn sibling_copies(&self, account_id: u32, folder_path: &str, uid: u32) -> Vec<(String, u32)> {
         let run = || -> rusqlite::Result<Vec<(String, u32)>> {
             let mut stmt = self.conn.prepare(
-                "SELECT folder_path, uid FROM messages \
-                 WHERE account_id = ?1 AND message_id != '' \
-                   AND message_id = (SELECT message_id FROM messages \
-                                     WHERE account_id = ?1 AND folder_path = ?2 AND uid = ?3) \
-                   AND NOT (folder_path = ?2 AND uid = ?3)",
+                "SELECT m.folder_path, m.uid FROM messages m \
+                 JOIN messages orig ON orig.account_id = ?1 \
+                                   AND orig.folder_path = ?2 AND orig.uid = ?3 \
+                 WHERE m.account_id = ?1 AND m.message_id != '' \
+                   AND m.message_id = orig.message_id \
+                   AND m.from_addr = orig.from_addr \
+                   AND m.ts = orig.ts \
+                   AND NOT (m.folder_path = ?2 AND m.uid = ?3)",
             )?;
             let rows = stmt.query_map(params![account_id, folder_path, uid], |row| {
                 Ok((row.get(0)?, row.get(1)?))
@@ -1289,6 +1302,18 @@ mod tests {
     }
 
     /// Insert a message carrying threading headers.
+    /// Like [`add_threaded`], but with a sender — for the checks that a shared
+    /// Message-ID alone is not enough to call two rows the same mail.
+    fn add_from(c: &Cache, folder: &str, uid: u32, ts: i64, msgid: &str, from: &str) {
+        c.conn
+            .execute(
+                "INSERT INTO messages (account_id, folder_path, uid, from_name, from_addr, subject, date, ts, unread, starred, has_attachment, message_id, references_) \
+                 VALUES (1, ?1, ?2, 'X', ?5, 'S', '', ?3, 0, 0, 0, ?4, '')",
+                params![folder, uid, ts, msgid, from],
+            )
+            .unwrap();
+    }
+
     fn add_threaded(c: &Cache, folder: &str, uid: u32, ts: i64, msgid: &str, refs: &str) {
         c.conn
             .execute(
@@ -1375,6 +1400,25 @@ mod tests {
             None,
             "an empty Message-ID matches nothing, not everything"
         );
+    }
+
+    /// Message-ID is written by the sender, and spam reuses one across unrelated
+    /// mail. Serving one message's body for another would be worse than the
+    /// cache miss the fallback exists to avoid, so sender and timestamp have to
+    /// agree too.
+    #[test]
+    fn a_reused_message_id_from_a_different_sender_answers_for_nothing() {
+        let c = Cache::in_memory();
+        add_from(&c, "INBOX", 42, 500, "dup@x", "me@real.example");
+        add_from(&c, "Archive", 900, 500, "dup@x", "spammer@fake.example");
+        c.save_body(1, "Archive", 900, "not the same mail");
+        assert_eq!(c.load_body(1, "INBOX", 42), None);
+
+        // Same sender, but a different message that happens to reuse the id.
+        add_from(&c, "INBOX", 43, 500, "dup2@x", "me@real.example");
+        add_from(&c, "Archive", 901, 900, "dup2@x", "me@real.example");
+        c.save_body(1, "Archive", 901, "a different day's mail");
+        assert_eq!(c.load_body(1, "INBOX", 43), None);
     }
 
     #[test]

--- a/src/ui/message_view.rs
+++ b/src/ui/message_view.rs
@@ -54,6 +54,9 @@ pub struct MessageView {
     /// False from when a render starts until the WebView reports it finished
     /// loading — a themed cover hides the WebView's white inter-document gap.
     webview_ready: bool,
+    /// Which message the document currently on screen was rendered for, so an
+    /// incremental re-render of the *same* one can skip the cover.
+    rendered_for: Option<(u32, u32)>,
     webview: webkit6::WebView,
     /// Bumped per render: each load gets a unique base URI so WebKit treats it
     /// as a fresh document and re-fetches resources (reusing `about:blank` does
@@ -426,6 +429,7 @@ impl Component for MessageView {
             chip_provider,
             loading: false,
             webview_ready: false,
+            rendered_for: None,
             webview,
             sender_check: None,
             link_preview: link_preview.clone(),
@@ -697,8 +701,16 @@ impl MessageView {
     fn render(&mut self) {
         let dark = self.effective_dark();
         self.apply_webview_bg(dark);
-        // Hide the WebView behind the themed cover until this load finishes.
-        self.webview_ready = false;
+        // Hide the WebView behind the themed cover until this load finishes —
+        // but only when the document on screen is being replaced by a different
+        // message. A conversation re-renders once per body that arrives, and
+        // covering it each time is what made a thread blink its way through
+        // loading; the old document stays up until WebKit swaps the new one in.
+        let target = self.current.as_ref().map(|m| (m.account_id, m.id));
+        if target.is_none() || target != self.rendered_for {
+            self.webview_ready = false;
+        }
+        self.rendered_for = target;
         let html = self.document_html(dark);
         let n = self.seq.get().wrapping_add(1);
         self.seq.set(n);

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -3691,19 +3691,27 @@ async fn load_bodies(
         .try_collect()
         .await?;
     let mut out = std::collections::HashMap::new();
+    let mut last_uid: Option<u32> = None;
     for f in &fetches {
-        let Some(uid) = f.uid else {
+        if let Some(u) = f.uid {
+            last_uid = Some(u);
+        }
+        // A message's response can arrive split across items — [`load_body`]
+        // scans every one of them for the body rather than trusting the first,
+        // and this has to be as forgiving. An item with no body is not an empty
+        // message, just not the part carrying one, so it is skipped: leaving the
+        // UID out of the map means the caller shows "(empty message)" without
+        // writing that over a real body in the cache.
+        let (Some(uid), Some(raw)) = (last_uid, f.body()) else {
             continue;
         };
-        let raw = f.body();
-        let body = raw
-            .map(extract_body)
-            .unwrap_or_else(|| "(empty message)".to_string());
-        let check = raw.map(crate::verify::check_sender).unwrap_or_default();
-        let has_attachments = raw
-            .map(|r| !extract_attachments(r).is_empty())
-            .unwrap_or(false);
-        out.insert(uid, (body, check, has_attachments));
+        out.entry(uid).or_insert_with(|| {
+            (
+                extract_body(raw),
+                crate::verify::check_sender(raw),
+                !extract_attachments(raw).is_empty(),
+            )
+        });
     }
     Ok(out)
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -76,6 +76,19 @@ pub enum MailRequest {
         path: String,
         uid: u32,
     },
+    /// Load several messages' bodies from one folder in a single IMAP fetch.
+    ///
+    /// Opening a conversation needs every member's body at once. Asked for one
+    /// at a time that is one round trip each — on a ten-message thread, ten
+    /// sequential waits on the server, and (because each arrival re-renders the
+    /// reader) ten redraws. `uid_fetch` takes a whole UID set, so the same work
+    /// is one round trip. Members cached on disk are served without touching the
+    /// network at all, and only the rest go into the set.
+    LoadBodies {
+        /// `(message_id, uid)` for each member, primary first.
+        items: Vec<(u32, u32)>,
+        path: String,
+    },
     /// Load the raw RFC 822 source of a single message.
     LoadSource {
         message_id: u32,
@@ -612,6 +625,10 @@ async fn run_imap(
             continue;
         }
 
+        // Bodies of a `LoadBodies` batch that the disk cache couldn't answer, so
+        // the network arm below fetches only those.
+        let mut pending_bodies: Vec<(u32, u32)> = Vec::new();
+
         // Serve from cache first so mail appears instantly (and offline).
         match &req {
             MailRequest::LoadMessages { folder_id, path } => {
@@ -678,6 +695,35 @@ async fn run_imap(
                         emit(WorkerEvent::SenderChecked { message_id: *message_id, check });
                     }
                     continue; // already cached; no network needed
+                }
+            }
+            MailRequest::LoadBodies { items, path } => {
+                // Serve every member the cache already has, and leave the rest
+                // for one fetch. A conversation reopened after its bodies were
+                // cached costs no network at all.
+                for (message_id, uid) in items {
+                    match cache.as_ref().and_then(|c| c.load_body(account_id, path, *uid)) {
+                        Some(body) => {
+                            emit(WorkerEvent::Body {
+                                message_id: *message_id,
+                                path: path.clone(),
+                                body,
+                            });
+                            if let Some(check) = cache
+                                .as_ref()
+                                .and_then(|c| c.load_sender_check(account_id, path, *uid))
+                            {
+                                emit(WorkerEvent::SenderChecked {
+                                    message_id: *message_id,
+                                    check,
+                                });
+                            }
+                        }
+                        None => pending_bodies.push((*message_id, *uid)),
+                    }
+                }
+                if pending_bodies.is_empty() {
+                    continue; // whole conversation was cached; no network needed
                 }
             }
             MailRequest::LoadAttachments {
@@ -814,6 +860,50 @@ async fn run_imap(
                     });
                 }
             },
+
+            MailRequest::LoadBodies { path, .. } => {
+                let uids: Vec<u32> = pending_bodies.iter().map(|(_, uid)| *uid).collect();
+                match load_bodies_retry(&mut session, &account, &path, &uids).await {
+                    Ok(mut fetched) => {
+                        for (message_id, uid) in &pending_bodies {
+                            let Some((body, check, has_attachments)) = fetched.remove(uid) else {
+                                // The server answered the set but not this UID —
+                                // the message is gone from the folder. Say so in
+                                // place, rather than leaving one member of the
+                                // conversation blank forever.
+                                emit(WorkerEvent::Body {
+                                    message_id: *message_id,
+                                    path: path.clone(),
+                                    body: "(empty message)".to_string(),
+                                });
+                                continue;
+                            };
+                            if let Some(c) = cache.as_ref() {
+                                c.save_body(account_id, &path, *uid, &body);
+                                c.save_sender_check(account_id, &path, *uid, &check);
+                                c.set_has_attachment(account_id, &path, *uid, has_attachments);
+                            }
+                            emit(WorkerEvent::Body {
+                                message_id: *message_id,
+                                path: path.clone(),
+                                body,
+                            });
+                            emit(WorkerEvent::SenderChecked { message_id: *message_id, check });
+                            emit(if has_attachments {
+                                WorkerEvent::HasAttachments { message_id: *message_id }
+                            } else {
+                                WorkerEvent::NoAttachments { message_id: *message_id }
+                            });
+                        }
+                    }
+                    Err(e) => {
+                        emit(WorkerEvent::Error {
+                            text: format!("Could not load conversation: {e}"),
+                            connectivity: true,
+                        });
+                    }
+                }
+            }
 
             MailRequest::LoadSource { path, uid, .. } => match load_source_retry(
                 &mut session,
@@ -1327,6 +1417,30 @@ async fn load_body_retry(
         if let Ok(fresh) = connect(account).await {
             s = fresh;
             res = load_body(&mut s, path, uid).await;
+        }
+    }
+    if res.is_ok() {
+        *session = Some(s);
+    }
+    res
+}
+
+/// [`load_bodies`] with [`load_body_retry`]'s one reconnect-and-retry.
+async fn load_bodies_retry(
+    session: &mut Option<ImapSession>,
+    account: &AccountConfig,
+    path: &str,
+    uids: &[u32],
+) -> Result<
+    std::collections::HashMap<u32, (String, crate::models::SenderCheck, bool)>,
+    async_imap::error::Error,
+> {
+    let mut s = session.take().expect("session ensured before call");
+    let mut res = load_bodies(&mut s, path, uids).await;
+    if res.is_err() {
+        if let Ok(fresh) = connect(account).await {
+            s = fresh;
+            res = load_bodies(&mut s, path, uids).await;
         }
     }
     if res.is_ok() {
@@ -3550,6 +3664,50 @@ async fn load_body(
     Ok((body, check, has_attachments))
 }
 
+/// Fetch several messages' bodies from one folder in a single `uid_fetch`.
+///
+/// The per-message extraction is [`load_body`]'s, applied to each response in
+/// the set: body, sender check and the attachment fact all come off the raw
+/// message that is already in hand, at no extra network cost. A UID the server
+/// doesn't answer is simply absent from the map — the caller decides what to
+/// show in its place.
+async fn load_bodies(
+    session: &mut ImapSession,
+    path: &str,
+    uids: &[u32],
+) -> Result<
+    std::collections::HashMap<u32, (String, crate::models::SenderCheck, bool)>,
+    async_imap::error::Error,
+> {
+    session.select(path).await?;
+    let set = uids
+        .iter()
+        .map(|u| u.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    let fetches: Vec<Fetch> = session
+        .uid_fetch(set, "(BODY.PEEK[])")
+        .await?
+        .try_collect()
+        .await?;
+    let mut out = std::collections::HashMap::new();
+    for f in &fetches {
+        let Some(uid) = f.uid else {
+            continue;
+        };
+        let raw = f.body();
+        let body = raw
+            .map(extract_body)
+            .unwrap_or_else(|| "(empty message)".to_string());
+        let check = raw.map(crate::verify::check_sender).unwrap_or_default();
+        let has_attachments = raw
+            .map(|r| !extract_attachments(r).is_empty())
+            .unwrap_or(false);
+        out.insert(uid, (body, check, has_attachments));
+    }
+    Ok(out)
+}
+
 /// Fetch BODYSTRUCTURE and return the IMAP section number of the preferred text
 /// part (HTML over plain). `None` for non-multipart messages (just fetch whole).
 #[allow(dead_code)]
@@ -4150,6 +4308,32 @@ async fn run_pop3(
                 }
             }
 
+            // POP3 has no set fetch — RETR is one message at a time — so a batch
+            // is the same work in a loop, saving only the per-message request hop.
+            MailRequest::LoadBodies { items, path: _ } => {
+                for (message_id, uid) in items {
+                    if let Some(body) =
+                        cache.as_ref().and_then(|c| c.load_body(account_id, INBOX, uid))
+                    {
+                        emit(WorkerEvent::Body { message_id, path: INBOX.to_string(), body });
+                        continue;
+                    }
+                    match pop3_fetch_raw(&account, uid).await {
+                        Ok(raw) => {
+                            let body = extract_body(&raw);
+                            if let Some(c) = cache.as_ref() {
+                                c.save_body(account_id, INBOX, uid, &body);
+                            }
+                            emit(WorkerEvent::Body { message_id, path: INBOX.to_string(), body });
+                        }
+                        Err(e) => emit(WorkerEvent::Error {
+                            text: format!("Could not load message: {e}"),
+                            connectivity: true,
+                        }),
+                    }
+                }
+            }
+
             MailRequest::LoadSource { message_id: _, path: _, uid } => {
                 match pop3_fetch_raw(&account, uid).await {
                     Ok(raw) => emit(WorkerEvent::Source {
@@ -4428,6 +4612,16 @@ async fn run_mock(
             MailRequest::LoadBody { message_id, ref path, .. } => {
                 let body = backend.message(message_id).map(|m| m.body).unwrap_or_default();
                 emit(WorkerEvent::Body { message_id, path: path.clone(), body });
+            }
+            MailRequest::LoadBodies { ref items, ref path } => {
+                for (message_id, _) in items {
+                    let body = backend.message(*message_id).map(|m| m.body).unwrap_or_default();
+                    emit(WorkerEvent::Body {
+                        message_id: *message_id,
+                        path: path.clone(),
+                        body,
+                    });
+                }
             }
             MailRequest::LoadSource { message_id, .. } => {
                 let text = backend.message(message_id).map(|m| m.body).unwrap_or_default();

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -58,6 +58,16 @@ const PREFETCH_LIMIT: usize = 25;
 const GALLERY_LIMIT: u32 = 300;
 const GALLERY_DATA_CAP: u64 = 6 * 1024 * 1024;
 
+/// How many messages one body fetch asks for.
+///
+/// `BODY.PEEK[]` returns whole messages, attachments included, so a whole
+/// conversation in one command — up to `THREAD_MEMBER_LIMIT` members — can be
+/// tens of megabytes arriving as a single response: nothing on screen until all
+/// of it lands, and nothing to show for it if the connection drops on the way.
+/// Ten still cuts the round trips to a fifth of what asking one at a time cost,
+/// while the reader fills in as each batch arrives.
+const BODY_FETCH_BATCH: usize = 10;
+
 /// Pre-download message *bodies* for this many of the most recent messages in a
 /// synced folder, so new mail opens instantly with no network wait. Bodies are
 /// small, so this stays cheap; older messages load on demand.
@@ -862,45 +872,60 @@ async fn run_imap(
             },
 
             MailRequest::LoadBodies { path, .. } => {
-                let uids: Vec<u32> = pending_bodies.iter().map(|(_, uid)| *uid).collect();
-                match load_bodies_retry(&mut session, &account, &path, &uids).await {
-                    Ok(mut fetched) => {
-                        for (message_id, uid) in &pending_bodies {
-                            let Some((body, check, has_attachments)) = fetched.remove(uid) else {
-                                // The server answered the set but not this UID —
-                                // the message is gone from the folder. Say so in
-                                // place, rather than leaving one member of the
-                                // conversation blank forever.
+                for group in pending_bodies.chunks(BODY_FETCH_BATCH) {
+                    // A failed batch leaves no session behind (the retry only
+                    // hands one back on success), so the rest of the conversation
+                    // needs one before it can go on.
+                    if session.is_none() {
+                        session = connect(&account).await.ok();
+                    }
+                    if session.is_none() {
+                        break; // still offline; what's left loads on reopen
+                    }
+                    let uids: Vec<u32> = group.iter().map(|(_, uid)| *uid).collect();
+                    match load_bodies_retry(&mut session, &account, &path, &uids).await {
+                        Ok(mut fetched) => {
+                            for (message_id, uid) in group {
+                                let Some((body, check, has_attachments)) = fetched.remove(uid)
+                                else {
+                                    // The server answered the set but not this
+                                    // UID — the message is gone from the folder.
+                                    // Say so in place, rather than leaving one
+                                    // member of the conversation blank forever.
+                                    emit(WorkerEvent::Body {
+                                        message_id: *message_id,
+                                        path: path.clone(),
+                                        body: "(empty message)".to_string(),
+                                    });
+                                    continue;
+                                };
+                                if let Some(c) = cache.as_ref() {
+                                    c.save_body(account_id, &path, *uid, &body);
+                                    c.save_sender_check(account_id, &path, *uid, &check);
+                                    c.set_has_attachment(account_id, &path, *uid, has_attachments);
+                                }
                                 emit(WorkerEvent::Body {
                                     message_id: *message_id,
                                     path: path.clone(),
-                                    body: "(empty message)".to_string(),
+                                    body,
                                 });
-                                continue;
-                            };
-                            if let Some(c) = cache.as_ref() {
-                                c.save_body(account_id, &path, *uid, &body);
-                                c.save_sender_check(account_id, &path, *uid, &check);
-                                c.set_has_attachment(account_id, &path, *uid, has_attachments);
+                                emit(WorkerEvent::SenderChecked {
+                                    message_id: *message_id,
+                                    check,
+                                });
+                                emit(if has_attachments {
+                                    WorkerEvent::HasAttachments { message_id: *message_id }
+                                } else {
+                                    WorkerEvent::NoAttachments { message_id: *message_id }
+                                });
                             }
-                            emit(WorkerEvent::Body {
-                                message_id: *message_id,
-                                path: path.clone(),
-                                body,
-                            });
-                            emit(WorkerEvent::SenderChecked { message_id: *message_id, check });
-                            emit(if has_attachments {
-                                WorkerEvent::HasAttachments { message_id: *message_id }
-                            } else {
-                                WorkerEvent::NoAttachments { message_id: *message_id }
+                        }
+                        Err(e) => {
+                            emit(WorkerEvent::Error {
+                                text: format!("Could not load conversation: {e}"),
+                                connectivity: true,
                             });
                         }
-                    }
-                    Err(e) => {
-                        emit(WorkerEvent::Error {
-                            text: format!("Could not load conversation: {e}"),
-                            connectivity: true,
-                        });
                     }
                 }
             }


### PR DESCRIPTION
## Where this came from

#42 was filed because conversation grouping stopped short: after updating, every
older thread showed as loose messages and the preference looked dead. That turned
out to be the cutoff 1.13.4 stamps into `state.toml` — working as designed, not a
bug.

**This PR does not change that decision.** But to see what threading an archive
actually costs, `threading_since` was set to 0 by hand and used that way for a
while. For the record, on an 8300-message cache going back to 2008 it produced
356 conversations covering 1828 messages, the largest of them 49 — inside
`THREAD_MEMBER_LIMIT`. Whether that changes the case for a settable cutoff is
for #42, not here.

What it did do is put a lot of conversations on screen, and three defects fell
out of using them. The first two meet any Gmail user under the default cutoff
too; the third is a cost the reader pays on every conversation.

## One message, three copies

Opening a conversation on a Gmail account shows every message three times, and
pays a network round trip for each copy. Both come from the same place: Gmail
exposes labels as IMAP folders, so one message is stored in INBOX, All Mail and
Important at once — three folder/UID pairs carrying a single Message-ID — while
the conversation code keys on those pairs.

Measured on that same cache: **1210 of one account's 1212 messages sit under more
than one label**, and 1131 of the other's 2562. This is the ordinary case for
Gmail, not an edge one.

## A six-message thread renders as eighteen

`merge_related` skips a related message only when the conversation already holds
its `(folder_id, uid)`:

```rust
if conv.iter().any(|m| m.folder_id == r.folder_id && m.uid == r.uid) {
    continue; // already in the conversation, from this folder's own index
}
```

The three label copies differ in both, so all three join. Replaying that rule
over the cache above reproduces it exactly — one thread of 6 distinct
Message-IDs comes back as 18 rows, 6 per label; another of 8 comes back as 24.
The thread count in the message list is right, because it groups by Message-ID;
only the reader is wrong.

Lowering the cutoff is not what exposes this — it only made it frequent enough
to count. Of the 38 messages in that cache that arrived after the date 1.13.4
stamped on its own, 16 already carry several labels, so a conversation forming in
new mail duplicates just the same. A fresh install hits it within days.

**Fix:** the related lookup's results are reduced to one copy per message before
merging. The copy from the folder the reader is showing wins, so the "from
folder X" label and the actions on a message refer to the mail actually on
screen.

## Cached data belongs to the copy, not the message

Bodies, sender checks and attachments are keyed by `(folder, uid)` too. A body
read while the user was in All Mail is invisible to the INBOX copy of the same
mail, and its downloaded attachments come back empty — so the reader offers a
"Load attachments" button for files already on disk. On the same cache, 412
copies have no body of their own while a sibling copy does, and 49 are missing
attachments a sibling has; attachments land almost anywhere but INBOX.

Showing all three copies had been hiding this, since one of them usually had the
data. Collapsing them exposed it.

**Fix:** `load_body`, `load_sender_check` and `load_attachments` fall back to the
message's other copies before reporting a miss. The exact copy is still tried
first, so the common path is unchanged.

## Identity is not Message-ID alone

Both fixes above match messages by Message-ID. It is written by whoever sent the
mail, and spam and some list software reuse one across genuinely different
messages — where serving one message's body for another would be worse than the
cache miss being avoided. Sender and timestamp have to agree as well.

Subject deliberately does not take part: `redecode_encoded_subjects` can rewrite
it under one label and not another.

This costs nothing where the match was meant to fire — the strict comparison
finds the same 412 borrowable bodies as the loose one, because no Message-ID in
that cache covers two different senders or timestamps.

## One fetch per conversation, and no blinking

Opening a conversation asked for each member's body separately — one
`MailRequest::LoadBody` each, answered one at a time with
`uid_fetch(uid, "(BODY.PEEK[])")`. A ten-message thread was ten sequential waits
on the server, and only 20.8% of that cache's messages have a body stored, so an
archived thread hits the network for nearly all of it.

`LoadBodies` takes a whole (account, folder) group and fetches the UID set at
once, in batches of ten. Ten rather than the whole thread on purpose:
`BODY.PEEK[]` returns whole messages, attachments included, so up to
`THREAD_MEMBER_LIMIT` of them in one command can be tens of megabytes in a single
response — nothing on screen until all of it lands, and nothing to show for it if
the connection drops, which one-at-a-time fetching never risked. Ten still cuts
round trips to a fifth. Members the disk cache can answer never reach the
network, and a batch that fails reconnects before the next rather than
abandoning the rest. POP3 has no set fetch, so its arm stays the loop it was.

The blinking has the same root. `render()` sets `webview_ready = false`, dropping
a themed cover over the reader until WebKit finishes loading — right for a new
message, wrong for the re-render each arriving body queues, because the
conversation is one document rebuilt in full every time. Bodies trickling in
covered and uncovered the reader once per arrival. The cover is now raised only
when the document is being replaced by a *different* message.

## Testing

`cargo test`: 176 pass. Nine are new and cover each claim above — three labels
collapsing to one message with the on-screen copy preferred, a copy of a message
already shown being dropped, messages without a Message-ID never merging, a
reused Message-ID from another sender (and from another date) matching nothing, a
body and attachments cached under one label answering for another, a
single-folder thread becoming one fetch in thread order, and a thread spanning
folders and accounts splitting per folder without losing members.

`cargo clippy` reports the same 19 warnings as `main` — no new ones.

Verified by building the branch as a Flatpak and running it against those two
accounts: the thread that showed 18 messages now shows 6, attachments appear
without asking, and the reader no longer blinks while a conversation loads.

## Notes

- Both accounts used for verification are Gmail, so the behaviour of these
  changes on other providers is reasoned from the code rather than measured.
  Where a message lives in exactly one folder the sibling lookup returns nothing
  and behaviour is unchanged; the batch fetch is plain RFC 3501 sequence-set
  syntax, and it uses `BODY.PEEK[]` rather than a BODYSTRUCTURE fast path, so it
  keeps clear of the iCloud parsing trouble noted in `load_body`.
- The sibling lookup scans `messages` on a cache miss. That is nothing at a few
  thousand rows, but an index on `(account_id, message_id)` would be worth adding
  before a fully indexed archive of hundreds of thousands.
- The second thread-assembly path, `merge_related`, still requests bodies one at
  a time; it was left alone to keep this change reviewable.
