### PR TITLE
Show PDF thumbnail previews in attachment gallery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,11 @@ adw = { package = "libadwaita", version = "0.7", features = ["v1_4"] }
 relm4 = { version = "0.9", features = ["macros", "libadwaita"] }
 relm4-components = "0.9"
 webkit6 = "0.4"
+# PDF thumbnails in the attachment gallery (first-page render via poppler-glib).
+poppler-rs = { version = "0.24", features = ["v20_9"] }
+# "png": only to enable cairo-rs's `ImageSurface::write_to_png`, used to hand a
+# rendered PDF page to gdk::Texture the same way every other thumbnail loads.
+cairo-rs = { version = "0.20", features = ["png"] }
 keyring = { version = "3", default-features = false, features = ["sync-secret-service", "crypto-rust"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/README.md
+++ b/README.md
@@ -118,13 +118,13 @@ runtime.
 **Fedora**
 
 ```sh
-sudo dnf install gtk4-devel libadwaita-devel webkitgtk6.0-devel
+sudo dnf install gtk4-devel libadwaita-devel webkitgtk6.0-devel poppler-devel
 ```
 
 **Debian / Ubuntu**
 
 ```sh
-sudo apt install libgtk-4-dev libadwaita-1-dev libwebkitgtk-6.0-dev
+sudo apt install libgtk-4-dev libadwaita-1-dev libwebkitgtk-6.0-dev libpoppler-glib-dev
 ```
 
 **Build & install**

--- a/co.hyprlab.Vireo.yml
+++ b/co.hyprlab.Vireo.yml
@@ -51,6 +51,39 @@ build-options:
     # built into the source and works out of the box.
 
 modules:
+  # PDF attachment thumbnails (gallery + in-message drawer) render via
+  # poppler-glib, which the GNOME runtime doesn't ship — every other library it
+  # links against (cairo, glib, fontconfig, freetype, gdk-pixbuf) already is.
+  # Config lifted from flathub's org.gnome.Evince manifest, with
+  # ENABLE_LIBOPENJPEG turned off to avoid pulling in an openjpeg module too:
+  # thumbnails don't need JPEG2000 support, just the common image formats.
+  - name: popplerdata
+    no-autogen: true
+    make-install-args:
+      - prefix=/app
+    sources:
+      - type: archive
+        url: https://poppler.freedesktop.org/poppler-data-0.4.12.tar.gz
+        sha256: c835b640a40ce357e1b83666aabd95edffa24ddddd49b8daff63adb851cdab74
+  - name: poppler
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_INSTALL_LIBDIR=/app/lib
+      - -DCMAKE_INSTALL_INCLUDEDIR=/app/include
+      - -DBUILD_GTK_TESTS=OFF
+      - -DBUILD_CPP_TESTS=OFF
+      - -DENABLE_CPP=OFF
+      - -DENABLE_BOOST=OFF
+      - -DENABLE_GOBJECT_INTROSPECTION=OFF
+      - -DENABLE_LIBOPENJPEG=OFF
+      - -DENABLE_QT5=OFF
+      - -DENABLE_QT6=OFF
+    cleanup:
+      - /bin
+    sources:
+      - type: archive
+        url: https://poppler.freedesktop.org/poppler-26.07.0.tar.xz
+        sha256: 304832f48f8a47fdca90c6b6d1f684e68f37c10c9a0726f345f4ca9df4ca01e2
   - name: vireo
     buildsystem: simple
     build-commands:

--- a/src/ui/attachment_drawer.rs
+++ b/src/ui/attachment_drawer.rs
@@ -1,10 +1,11 @@
 //! In-message attachment drawer: a resizable footer beneath the reader body that
 //! shows every attachment on the open message as a wrapping grid of thumbnails
-//! (images) or colour-coded type icons (everything else), each with the filename
-//! beneath it.
+//! (images and PDFs) or colour-coded type icons (everything else), each with the
+//! filename beneath it.
 //!
 //! It reuses the gallery's thumbnail/icon/open helpers ([`texture_from`],
-//! [`icon_for`], [`icon_color_class`], [`open_bytes`]). Hovering a cell reveals
+//! [`thumbnail_texture`], [`icon_for`], [`icon_color_class`], [`open_bytes`]).
+//! Hovering a cell reveals
 //! the same Download/Open quick actions used in the gallery; right-clicking opens
 //! a matching context menu; single-clicking an image opens a modal lightbox
 //! (prev/next through the message's images), and clicking a non-image opens it in
@@ -26,7 +27,9 @@ use relm4::prelude::*;
 
 use crate::config::{self, DrawerState};
 use crate::models::{is_image_name, Attachment};
-use crate::ui::attachments_gallery::{icon_color_class, icon_for, open_bytes, texture_from};
+use crate::ui::attachments_gallery::{
+    icon_color_class, icon_for, open_bytes, texture_from, thumbnail_texture,
+};
 
 const MIN_THUMB: f64 = 56.0;
 const MAX_THUMB: f64 = 220.0;
@@ -285,7 +288,7 @@ impl SimpleComponent for AttachmentDrawer {
             }
             AttachmentDrawerInput::Open(i) => {
                 if let Some(att) = self.items.get(i) {
-                    open_bytes(&att.name, &att.data);
+                    open_bytes(&att.name, &att.data, self.window().as_ref());
                 }
             }
             AttachmentDrawerInput::Download(i) => {
@@ -298,7 +301,7 @@ impl SimpleComponent for AttachmentDrawer {
                 if is_image_name(&att.name) && texture_from(&att.data).is_some() {
                     self.show_lightbox(i);
                 } else {
-                    open_bytes(&att.name, &att.data);
+                    open_bytes(&att.name, &att.data, self.window().as_ref());
                 }
             }
             AttachmentDrawerInput::ContextMenu { index, x, y } => {
@@ -602,9 +605,10 @@ impl AttachmentDrawer {
         {
             let images = images.clone();
             let pos = pos.clone();
+            let win = win.clone();
             open_btn.connect_clicked(move |_| {
                 let (name, data) = &images[pos.get()];
-                open_bytes(name, data);
+                open_bytes(name, data, Some(&win));
             });
         }
         {
@@ -643,8 +647,8 @@ fn nav_button(icon: &str, tip: &str) -> gtk::Button {
     b
 }
 
-/// Build one grid cell: a square thumbnail (image texture or type icon) with
-/// hover Download/Open actions and the filename beneath it.
+/// Build one grid cell: a square thumbnail (image/PDF texture or type icon)
+/// with hover Download/Open actions and the filename beneath it.
 fn build_cell(
     index: usize,
     att: &Attachment,
@@ -655,11 +659,9 @@ fn build_cell(
     cell.add_css_class("drawer-cell");
     cell.set_halign(gtk::Align::Center);
 
-    // The thumbnail content: a cover-cropped image, or a centred type icon.
-    let content: gtk::Widget = match is_image_name(&att.name)
-        .then(|| texture_from(&att.data))
-        .flatten()
-    {
+    // The thumbnail content: a cover-cropped image/PDF-page render, or a
+    // centred type icon.
+    let content: gtk::Widget = match thumbnail_texture(&att.name, &att.data) {
         Some(tex) => {
             let pic = gtk::Picture::for_paintable(&tex);
             pic.set_content_fit(gtk::ContentFit::Cover);

--- a/src/ui/attachments_gallery.rs
+++ b/src/ui/attachments_gallery.rs
@@ -2,16 +2,16 @@
 //! inboxes, with a lightbox preview (prev/next, open, go to message).
 //!
 //! Data comes from the SQLite cache (what the background prefetch has already
-//! downloaded), fed in via [`GalleryInput::SetItems`]. Image attachments show as
-//! thumbnails; other files show a type icon. Clicking a cell opens a large
-//! overlay preview.
+//! downloaded), fed in via [`GalleryInput::SetItems`]. Image attachments and PDFs
+//! (rendered from their first page) show as thumbnails; other files show a type
+//! icon. Clicking a cell opens a large overlay preview.
 
 use gtk::gdk;
 use gtk::glib;
 use gtk::prelude::*;
 use relm4::prelude::*;
 
-use crate::models::GalleryItem;
+use crate::models::{is_image_name, GalleryItem};
 
 pub struct AttachmentsGallery {
     /// Full set of attachments, unfiltered — the source for search and sort.
@@ -519,7 +519,8 @@ impl AttachmentsGallery {
     fn open_item(&self, index: usize) {
         if let Some(item) = self.item_at(index) {
             if let Some(data) = &item.data {
-                open_bytes(&item.name, data);
+                let parent = self.flow.root().and_downcast::<gtk::Window>();
+                open_bytes(&item.name, data, parent.as_ref());
             }
         }
     }
@@ -615,7 +616,8 @@ impl AttachmentsGallery {
     }
 }
 
-/// One grid cell: a thumbnail (image) or type icon, plus name + size.
+/// One grid cell: a thumbnail (image or PDF first page) or type icon, plus name
+/// + size.
 fn build_cell(
     index: usize,
     item: &GalleryItem,
@@ -632,11 +634,7 @@ fn build_cell(
     thumb_holder.set_halign(gtk::Align::Fill);
     thumb_holder.set_valign(gtk::Align::Fill);
 
-    let thumb = item
-        .is_image()
-        .then_some(item.data.as_ref())
-        .flatten()
-        .and_then(|d| texture_from(d));
+    let thumb = item.data.as_ref().and_then(|d| thumbnail_texture(&item.name, d));
     match thumb {
         Some(tex) => {
             let pic = gtk::Picture::for_paintable(&tex);
@@ -859,6 +857,53 @@ pub(crate) fn texture_from(data: &[u8]) -> Option<gdk::Texture> {
     gdk::Texture::from_bytes(&glib::Bytes::from(data)).ok()
 }
 
+/// A grid-cell thumbnail for any attachment type that has one: a decoded image,
+/// or a PDF's first page. `None` for anything else, so the caller falls back to
+/// the type icon.
+pub(crate) fn thumbnail_texture(name: &str, data: &[u8]) -> Option<gdk::Texture> {
+    if is_image_name(name) {
+        texture_from(data)
+    } else if name.to_ascii_lowercase().ends_with(".pdf") {
+        pdf_thumbnail(data)
+    } else {
+        None
+    }
+}
+
+/// Render a PDF's first page to a texture, by way of an in-memory PNG — the
+/// same route every other thumbnail here already goes through, so cropping,
+/// caching, and format all stay uniform.
+fn pdf_thumbnail(data: &[u8]) -> Option<gdk::Texture> {
+    let doc = poppler::Document::from_bytes(&glib::Bytes::from(data), None).ok()?;
+    let page = doc.page(0)?;
+    let (w, h) = page.size();
+    if w <= 0.0 || h <= 0.0 {
+        return None;
+    }
+    // Poppler's default is one pixel per point (72 dpi) — fine for text but
+    // soft as a thumbnail, so render at a fixed, sharper width instead.
+    const TARGET_WIDTH: f64 = 360.0;
+    let scale = TARGET_WIDTH / w;
+    let surface = gtk::cairo::ImageSurface::create(
+        gtk::cairo::Format::ARgb32,
+        TARGET_WIDTH.round() as i32,
+        (h * scale).round() as i32,
+    )
+    .ok()?;
+    let cr = gtk::cairo::Context::new(&surface).ok()?;
+    // A PDF page's own background is transparent; without painting white first,
+    // the thumbnail would show through to whatever is behind it (a hole in
+    // dark mode rather than a page).
+    cr.set_source_rgb(1.0, 1.0, 1.0);
+    cr.paint().ok()?;
+    cr.scale(scale, scale);
+    page.render(&cr);
+    drop(cr);
+    let mut png = Vec::new();
+    surface.write_to_png(&mut png).ok()?;
+    texture_from(&png)
+}
+
 /// A symbolic icon name for a filename by extension.
 pub(crate) fn icon_for(name: &str) -> &'static str {
     let lower = name.to_ascii_lowercase();
@@ -909,7 +954,13 @@ pub(crate) fn icon_color_class(name: &str) -> &'static str {
 /// (under Flatpak it is per-app): the directory is created private and its
 /// ownership checked, and each file is created fresh rather than written
 /// through whatever already sits at a guessable path.
-pub(crate) fn open_bytes(name: &str, data: &[u8]) {
+///
+/// Launched through the portal's `UriLauncher` rather than
+/// `AppInfo::launch_default_for_uri`: for a type with no registered default
+/// (common for attachments — nothing may ever have been "set as default" for
+/// a `.pdf`) the portal falls back to GNOME's own app-chooser dialog instead
+/// of silently doing nothing.
+pub(crate) fn open_bytes(name: &str, data: &[u8], parent: Option<&gtk::Window>) {
     let safe: String = name
         .chars()
         .map(|c| if c.is_alphanumeric() || matches!(c, '.' | '-' | '_') { c } else { '_' })
@@ -929,7 +980,17 @@ pub(crate) fn open_bytes(name: &str, data: &[u8]) {
     }
     drop(file);
     let uri = format!("file://{}", path.to_string_lossy());
-    let _ = gtk::gio::AppInfo::launch_default_for_uri(&uri, gtk::gio::AppLaunchContext::NONE);
+    gtk::UriLauncher::new(&uri).launch(parent, gtk::gio::Cancellable::NONE, move |res| {
+        // Falls back to the non-portal launch path if the portal itself is
+        // unreachable or misbehaving (some sandboxes/containers, or a desktop
+        // with no working `xdg-desktop-portal` backend) rather than leaving
+        // the click looking like it did nothing.
+        if let Err(e) = res {
+            tracing::warn!("portal launch failed, falling back: {e}");
+            let _ =
+                gtk::gio::AppInfo::launch_default_for_uri(&uri, gtk::gio::AppLaunchContext::NONE);
+        }
+    });
 }
 
 /// The private directory opened attachments are staged in, created if needed.
@@ -990,7 +1051,7 @@ fn create_private(
             use std::os::unix::fs::OpenOptionsExt;
             opts.mode(0o600);
             // Refuse to follow a symlink instead of racing to check for one.
-            opts.custom_flags(0o200000 /* O_NOFOLLOW */);
+            opts.custom_flags(0o400000 /* O_NOFOLLOW */);
         }
         if let Ok(file) = opts.open(&path) {
             return Some((file, path));
@@ -1141,6 +1202,59 @@ mod tests {
         assert!(type_keywords("a.png").contains("image"));
         assert!(type_keywords("a.mp3").contains("audio"));
         assert!(type_keywords("a.ics").contains("calendar"));
+    }
+
+    /// A minimal one-page PDF, built by hand — just enough structure for
+    /// poppler to load and render, with no dependency on an external file.
+    fn minimal_pdf() -> Vec<u8> {
+        let content = b"1 0 0 rg 100 100 300 300 re f";
+        let objects = [
+            "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 400] /Contents 4 0 R >>".to_string(),
+            format!(
+                "<< /Length {} >>\nstream\n{}\nendstream",
+                content.len(),
+                std::str::from_utf8(content).unwrap()
+            ),
+        ];
+        let mut out = Vec::new();
+        out.extend_from_slice(b"%PDF-1.4\n");
+        let mut offsets = vec![0usize];
+        for (i, obj) in objects.iter().enumerate() {
+            offsets.push(out.len());
+            out.extend_from_slice(format!("{} 0 obj\n", i + 1).as_bytes());
+            out.extend_from_slice(obj.as_bytes());
+            out.extend_from_slice(b"\nendobj\n");
+        }
+        let xref_offset = out.len();
+        out.extend_from_slice(format!("xref\n0 {}\n", objects.len() + 1).as_bytes());
+        out.extend_from_slice(b"0000000000 65535 f \n");
+        for off in &offsets[1..] {
+            out.extend_from_slice(format!("{off:010} 00000 n \n").as_bytes());
+        }
+        out.extend_from_slice(
+            format!(
+                "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF",
+                objects.len() + 1,
+                xref_offset
+            )
+            .as_bytes(),
+        );
+        out
+    }
+
+    #[test]
+    fn thumbnail_texture_renders_pdf_first_page() {
+        let tex =
+            thumbnail_texture("attachment.pdf", &minimal_pdf()).expect("should render a page");
+        assert!(tex.width() > 0 && tex.height() > 0);
+    }
+
+    #[test]
+    fn thumbnail_texture_is_none_for_unsupported_types() {
+        assert!(thumbnail_texture("archive.zip", b"not a real zip").is_none());
+        assert!(thumbnail_texture("notes.pdf", b"not a real pdf").is_none());
     }
 
     #[test]


### PR DESCRIPTION
Renders PDF's first page via poppler-glib instead of showing the generic file icon; adds the poppler/cairo-rs deps and a matching Flatpak module. See issue: https://github.com/hyprlab/vireo/issues/48