### PR TITLE
Tweak right-click context menu visuals

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -182,6 +182,24 @@ headerbar.rail-header {
   background: alpha(currentColor, 0.08);
 }
 
+/* Right-click context menus (see ui/context_menu.rs): a flat icon + label
+   button per row, padded and rounded like GNOME's native popover menu items.
+   Real menu rows (GtkModelButton/PopoverMenu items) are regular weight and a
+   comfortable minimum width regardless of label length — plain GtkButton
+   defaults to bold text and hugs its content, so both are overridden here. */
+.context-menu-list {
+  padding: 6px;
+  min-width: 190px;
+}
+.context-menu-item {
+  padding: 8px 10px;
+  border-radius: 6px;
+}
+.context-menu-item,
+.context-menu-item label {
+  font-weight: normal;
+}
+
 /* Reader attachment popover rows. */
 .attach-row {
   padding: 4px 6px;

--- a/src/ui/attachment_drawer.rs
+++ b/src/ui/attachment_drawer.rs
@@ -28,6 +28,7 @@ use relm4::prelude::*;
 
 use crate::config::{self, DrawerState};
 use crate::models::{is_image_name, Attachment};
+use crate::ui::context_menu::{show_context_menu, MenuEntry};
 use crate::ui::attachments_gallery::{
     icon_color_class, icon_for, is_pdf_name, open_bytes, spawn_thumbnail_render, texture_from,
     thumbnail_texture, Thumbnail,
@@ -90,8 +91,6 @@ pub struct AttachmentDrawer {
     collapsed: bool,
     /// The wrapping thumbnail grid (rebuilt on item/size changes).
     flow: gtk::FlowBox,
-    /// Reusable right-click context menu, parented to the grid.
-    menu: gtk::Popover,
     /// Vertical split: reader body on top, drawer body below. The divider is the
     /// resize grip — native drag, and the reader shrinks rather than the window
     /// growing.
@@ -321,9 +320,6 @@ impl SimpleComponent for AttachmentDrawer {
     ) -> ComponentParts<Self> {
         let flow = gtk::FlowBox::default();
         let scroller = gtk::ScrolledWindow::default();
-        let menu = gtk::Popover::new();
-        menu.set_has_arrow(false);
-        menu.set_position(gtk::PositionType::Bottom);
 
         let model = AttachmentDrawer {
             items: Vec::new(),
@@ -334,7 +330,6 @@ impl SimpleComponent for AttachmentDrawer {
             height: init.state.height.max(MIN_HEIGHT),
             collapsed: init.state.collapsed,
             flow: flow.clone(),
-            menu: menu.clone(),
             // The root of this component IS the Paned.
             paned: root.clone(),
             adjusting: Rc::new(Cell::new(false)),
@@ -344,7 +339,6 @@ impl SimpleComponent for AttachmentDrawer {
         let widgets = view_output!();
         // Dock the reader as the top pane (the drawer body is the bottom pane).
         root.set_start_child(Some(&init.reader));
-        model.menu.set_parent(&model.flow);
         ComponentParts { model, widgets }
     }
 
@@ -491,10 +485,10 @@ impl AttachmentDrawer {
 
     /// Rebuild the thumbnail grid from the current items and thumbnail size.
     fn rebuild(&mut self, sender: &ComponentSender<Self>) {
-        // Remove existing cells only. The context-menu popover is also parented
-        // to the flow, so skip anything that isn't a FlowBoxChild — and walk
-        // siblings captured before removal so this can never loop (removing a
-        // non-child is a no-op, which would spin `first_child()` forever).
+        // Remove existing cells only, skipping anything that isn't a
+        // FlowBoxChild — and walk siblings captured before removal so this can
+        // never loop (removing a non-child is a no-op, which would spin
+        // `first_child()` forever).
         let mut child = self.flow.first_child();
         while let Some(c) = child {
             let next = c.next_sibling();
@@ -550,43 +544,20 @@ impl AttachmentDrawer {
 
     /// Right-click menu: Open / Download, matching the gallery's actions.
     fn show_context_menu(&self, index: usize, x: f64, y: f64, sender: &ComponentSender<Self>) {
-        let list = gtk::Box::new(gtk::Orientation::Vertical, 0);
-        list.set_width_request(160);
-        let item = |icon: &str, label: &str| {
-            let b = gtk::Button::new();
-            b.add_css_class("flat");
-            let row = gtk::Box::new(gtk::Orientation::Horizontal, 8);
-            row.append(&gtk::Image::from_icon_name(icon));
-            let l = gtk::Label::new(Some(label));
-            l.set_halign(gtk::Align::Start);
-            l.set_hexpand(true);
-            row.append(&l);
-            b.set_child(Some(&row));
-            b
-        };
-
-        let open = item("co.hyprlab.Vireo-document-open-symbolic", "Open");
         let s = sender.clone();
-        let menu = self.menu.clone();
-        open.connect_clicked(move |_| {
-            menu.popdown();
-            s.input(AttachmentDrawerInput::Open(index));
-        });
-        list.append(&open);
-
-        let download = item("co.hyprlab.Vireo-folder-download-symbolic", "Download…");
+        let open = MenuEntry::new("Open", move || s.input(AttachmentDrawerInput::Open(index)));
         let s = sender.clone();
-        let menu = self.menu.clone();
-        download.connect_clicked(move |_| {
-            menu.popdown();
-            s.input(AttachmentDrawerInput::Download(index));
-        });
-        list.append(&download);
+        let download =
+            MenuEntry::new("Download…", move || s.input(AttachmentDrawerInput::Download(index)));
 
-        self.menu.set_child(Some(&list));
-        self.menu
-            .set_pointing_to(Some(&gtk::gdk::Rectangle::new(x as i32, y as i32, 1, 1)));
-        self.menu.popup();
+        // Anchor on the clicked cell itself so the click point (already
+        // relative to it) needs no coordinate translation.
+        let parent: gtk::Widget = self
+            .flow
+            .child_at_index(index as i32)
+            .map(|c| c.upcast())
+            .unwrap_or_else(|| self.flow.clone().upcast());
+        show_context_menu(&parent, x, y, vec![vec![open, download]]);
     }
 
     /// Ask the app to show its full-window lightbox over the message's

--- a/src/ui/attachments_gallery.rs
+++ b/src/ui/attachments_gallery.rs
@@ -12,6 +12,7 @@ use gtk::prelude::*;
 use relm4::prelude::*;
 
 use crate::models::{is_image_name, GalleryItem};
+use crate::ui::context_menu::{show_context_menu, MenuEntry};
 
 /// Width of the table's trailing quick-actions column (three icon buttons);
 /// the header carries a spacer of the same width so the columns line up.
@@ -43,8 +44,8 @@ pub struct AttachmentsGallery {
     flow: gtk::FlowBox,
     /// The table view's rows (the grid's sibling stack page).
     table: gtk::ListBox,
-    /// Reusable right-click context menu, parented to the gallery root.
-    menu: gtk::Popover,
+    /// The component's root widget, used to anchor the right-click context menu.
+    root: gtk::Widget,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
@@ -554,10 +555,6 @@ impl Component for AttachmentsGallery {
         root: Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
-        let menu = gtk::Popover::new();
-        menu.set_has_arrow(false);
-        menu.set_position(gtk::PositionType::Bottom);
-        menu.add_css_class("menu");
         let (view_table, thumb_width, sort_index) = crate::config::load_gallery_view();
         let model = AttachmentsGallery {
             all_items: Vec::new(),
@@ -573,14 +570,11 @@ impl Component for AttachmentsGallery {
             resize_timer: None,
             flow: gtk::FlowBox::new(),
             table: gtk::ListBox::new(),
-            menu,
+            root: root.clone().upcast(),
         };
         let flow = &model.flow;
         let table = &model.table;
         let widgets = view_output!();
-        // Parent the context menu to the gallery root (not the FlowBox, whose
-        // children must be FlowBoxChild and which we clear on every rebuild).
-        model.menu.set_parent(&root);
 
         // Double-clicking the preview opens the document in its external app.
         let dbl = gtk::GestureClick::new();
@@ -929,59 +923,24 @@ impl AttachmentsGallery {
         let Some(item) = self.item_at(index) else { return };
         let has_data = item.data.is_some();
 
-        let menu = gtk::Box::new(gtk::Orientation::Vertical, 0);
-        let item_btn = |label: &str, enabled: bool| {
-            let b = gtk::Button::with_label(label);
-            b.add_css_class("flat");
-            b.set_sensitive(enabled);
-            let child = b.child().and_downcast::<gtk::Label>();
-            if let Some(l) = child {
-                l.set_xalign(0.0);
-                l.set_halign(gtk::Align::Start);
-            }
-            b
-        };
+        let s = sender.clone();
+        let open =
+            MenuEntry::new("Open", move || s.input(GalleryInput::OpenItem(index))).enabled(has_data);
+        let s = sender.clone();
+        let download = MenuEntry::new("Download…", move || s.input(GalleryInput::DownloadItem(index)))
+            .enabled(has_data);
+        let s = sender.clone();
+        let goto = MenuEntry::new("Go to Message", move || s.input(GalleryInput::GoToItem(index)));
+        let sections = vec![vec![open, download, goto]];
 
-        let download = item_btn("Download…", has_data);
-        let open = item_btn("Open", has_data);
-        let goto = item_btn("Go to Message", true);
-        for b in [&download, &open, &goto] {
-            menu.append(b);
-        }
-        let s = sender.clone();
-        download.connect_clicked(move |_| s.input(GalleryInput::DownloadItem(index)));
-        let s = sender.clone();
-        open.connect_clicked(move |_| s.input(GalleryInput::OpenItem(index)));
-        let s = sender.clone();
-        goto.connect_clicked(move |_| s.input(GalleryInput::GoToItem(index)));
-        // Close the popover on any choice.
-        let pop = self.menu.clone();
-        for b in [&download, &open, &goto] {
-            let p = pop.clone();
-            b.connect_clicked(move |_| p.popdown());
-        }
-
-        self.menu.set_child(Some(&menu));
-        // Point at the click position, translated from the clicked cell/row
-        // into the menu parent's coordinate space, so it opens under the
-        // pointer whichever view is showing.
+        // Anchor on the clicked cell/row itself so the click point (already
+        // relative to it) needs no coordinate translation.
         let source: Option<gtk::Widget> = if self.view_table {
             self.table.row_at_index(index as i32).map(|r| r.upcast())
         } else {
             self.flow.child_at_index(index as i32).map(|c| c.upcast())
         };
-        if let (Some(child), Some(parent)) = (source, self.menu.parent()) {
-            let point = gtk::graphene::Point::new(x as f32, y as f32);
-            if let Some(p) = child.compute_point(&parent, &point) {
-                self.menu.set_pointing_to(Some(&gtk::gdk::Rectangle::new(
-                    p.x() as i32,
-                    p.y() as i32,
-                    1,
-                    1,
-                )));
-            }
-        }
-        self.menu.popup();
+        show_context_menu(source.as_ref().unwrap_or(&self.root), x, y, sections);
     }
 }
 

--- a/src/ui/context_menu.rs
+++ b/src/ui/context_menu.rs
@@ -1,0 +1,85 @@
+//! A shared builder for right-click context menus, styled to match GNOME HIG:
+//! a flat list of label rows in a borderless `GtkPopover`, grouped into
+//! sections by hairline separators. Built from plain widgets (not a
+//! `Gio.Menu`/`GtkPopoverMenu`, which on GTK4 wraps everything in an internal
+//! `GtkScrolledWindow`), so the popover and its box always size to exactly
+//! what the sections need and never grow a scrollbar.
+
+use gtk::prelude::*;
+
+/// One entry in a context menu: a label and the callback to run on
+/// activation. Use `.enabled(false)` to grey an item out rather than hiding
+/// it — HIG prefers a disabled item users can still find over one that
+/// vanishes and makes the menu shift under them.
+pub struct MenuEntry {
+    label: String,
+    enabled: bool,
+    activate: Box<dyn Fn()>,
+}
+
+impl MenuEntry {
+    pub fn new(label: impl Into<String>, activate: impl Fn() + 'static) -> Self {
+        Self { label: label.into(), enabled: true, activate: Box::new(activate) }
+    }
+
+    pub fn enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+}
+
+/// Build and pop up a HIG-style context menu anchored at `(x, y)` in
+/// `parent`'s own coordinate space (typically the exact widget the
+/// right-click landed on, so no coordinate translation is needed). `sections`
+/// groups entries into visually separated clusters, e.g. `[[Reply, Reply All,
+/// Forward], [Star, Mark Read], [Spam, Archive, Delete]]`.
+pub fn show_context_menu(parent: &impl IsA<gtk::Widget>, x: f64, y: f64, sections: Vec<Vec<MenuEntry>>) {
+    let popover = gtk::Popover::new();
+    popover.set_has_arrow(false);
+    popover.set_position(gtk::PositionType::Bottom);
+    popover.add_css_class("menu");
+
+    let list = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    list.add_css_class("context-menu-list");
+
+    let mut first = true;
+    for entries in sections {
+        if entries.is_empty() {
+            continue;
+        }
+        if !first {
+            list.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
+        }
+        first = false;
+
+        for entry in entries {
+            let MenuEntry { label, enabled, activate } = entry;
+
+            let lbl = gtk::Label::new(Some(&label));
+            lbl.set_xalign(0.0);
+            lbl.set_hexpand(true);
+
+            let btn = gtk::Button::new();
+            btn.set_child(Some(&lbl));
+            btn.add_css_class("flat");
+            btn.add_css_class("context-menu-item");
+            btn.set_halign(gtk::Align::Fill);
+            btn.set_sensitive(enabled);
+
+            let weak = popover.downgrade();
+            btn.connect_clicked(move |_| {
+                activate();
+                if let Some(p) = weak.upgrade() {
+                    p.popdown();
+                }
+            });
+            list.append(&btn);
+        }
+    }
+
+    popover.set_child(Some(&list));
+    popover.set_parent(parent);
+    popover.set_pointing_to(Some(&gtk::gdk::Rectangle::new(x as i32, y as i32, 1, 1)));
+    popover.connect_closed(|p| p.unparent());
+    popover.popup();
+}

--- a/src/ui/message_list.rs
+++ b/src/ui/message_list.rs
@@ -6,6 +6,7 @@ use relm4::factory::FactoryVecDeque;
 use relm4::prelude::*;
 
 use crate::models::Message;
+use crate::ui::context_menu::{show_context_menu, MenuEntry};
 
 /// Max rows rendered at once. GtkListBox isn't virtualized, so the full folder
 /// index is kept in memory for search but only this many rows are built.
@@ -994,8 +995,6 @@ pub struct MessageList {
     account_colors: std::collections::HashMap<u32, String>,
     /// Display-wide provider with each account's pale row-tint rule.
     color_provider: gtk::CssProvider,
-    /// Reusable popover for the per-message right-click menu.
-    context_popover: gtk::Popover,
     /// Actions Palette collapse delay (seconds), shared with every row.
     palette_collapse_secs: std::rc::Rc<std::cell::Cell<u64>>,
     /// The message currently being viewed, kept selected across list rebuilds.
@@ -1505,11 +1504,6 @@ impl SimpleComponent for MessageList {
             );
         }
 
-        let context_popover = gtk::Popover::new();
-        context_popover.set_has_arrow(false);
-        context_popover.set_position(gtk::PositionType::Bottom);
-        context_popover.add_css_class("menu");
-
         let mut model = MessageList {
             rows,
             all: Vec::new(),
@@ -1529,7 +1523,6 @@ impl SimpleComponent for MessageList {
             colorize: false,
             account_colors: std::collections::HashMap::new(),
             color_provider,
-            context_popover,
             palette_collapse_secs: std::rc::Rc::new(std::cell::Cell::new(5)),
             thread_links: Vec::new(),
             drag_keys: DragKeys::default(),
@@ -1552,7 +1545,6 @@ impl SimpleComponent for MessageList {
         };
 
         let row_box = model.rows.widget();
-        model.context_popover.set_parent(row_box);
 
         // Right-click (or long-press) a row to open its context menu.
         let click = gtk::GestureClick::new();
@@ -2182,97 +2174,62 @@ impl MessageList {
         y: f64,
         sender: &ComponentSender<Self>,
     ) {
-        let menu = gtk::Box::new(gtk::Orientation::Vertical, 0);
-        menu.add_css_class("context-menu");
-        let pop = self.context_popover.clone();
-        let item = |label: &str, action: RowAction| -> gtk::Button {
-            let btn = gtk::Button::with_label(label);
-            btn.add_css_class("flat");
-            btn.set_halign(gtk::Align::Fill);
-            if let Some(lbl) = btn.child().and_downcast::<gtk::Label>() {
-                lbl.set_xalign(0.0);
-            }
+        let item = |action: RowAction, label: &str| -> MenuEntry {
             let s = sender.clone();
-            let p = pop.clone();
             let m = msg.clone();
-            btn.connect_clicked(move |_| {
+            MenuEntry::new(label, move || {
                 let _ = s.output(MessageListOutput::Action {
                     action,
                     message: Box::new(m.clone()),
                 });
-                p.popdown();
-            });
-            btn
+            })
         };
 
-        menu.append(&item("Reply", RowAction::Reply));
-        menu.append(&item("Reply All", RowAction::ReplyAll));
-        menu.append(&item("Forward", RowAction::Forward));
-        menu.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
-        menu.append(&item(
-            if msg.starred { "Remove Star" } else { "Star" },
-            RowAction::ToggleStar,
-        ));
-        menu.append(&item(
-            if msg.unread { "Mark as Read" } else { "Mark as Unread" },
-            RowAction::ToggleRead,
-        ));
-        menu.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
-        menu.append(&item("Mark as Spam", RowAction::Spam));
-        menu.append(&item("Archive", RowAction::Archive));
-        menu.append(&item("Delete", RowAction::Delete));
-        menu.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
-        menu.append(&item("View Source", RowAction::ViewSource));
+        let sections = vec![
+            vec![
+                item(RowAction::Reply, "Reply"),
+                item(RowAction::ReplyAll, "Reply All"),
+                item(RowAction::Forward, "Forward"),
+            ],
+            vec![
+                item(RowAction::ToggleStar, if msg.starred { "Remove Star" } else { "Star" }),
+                item(
+                    RowAction::ToggleRead,
+                    if msg.unread { "Mark as Read" } else { "Mark as Unread" },
+                ),
+            ],
+            vec![
+                item(RowAction::Spam, "Mark as Spam"),
+                item(RowAction::Archive, "Archive"),
+                item(RowAction::Delete, "Delete"),
+            ],
+            vec![item(RowAction::ViewSource, "View Source")],
+        ];
 
-        self.context_popover.set_child(Some(&menu));
-        self.context_popover
-            .set_pointing_to(Some(&gtk::gdk::Rectangle::new(x as i32, y as i32, 1, 1)));
-        self.context_popover.popup();
+        show_context_menu(self.rows.widget(), x, y, sections);
     }
 
     /// Build and pop up the bulk-action menu for the current multi-selection.
     fn show_bulk_menu(&self, x: f64, y: f64, sender: &ComponentSender<Self>) {
-        let menu = gtk::Box::new(gtk::Orientation::Vertical, 0);
-        menu.add_css_class("context-menu");
-        let pop = self.context_popover.clone();
-        let count = self.selection_count;
-        let item = |label: &str, action: BulkAction| -> gtk::Button {
-            let btn = gtk::Button::with_label(label);
-            btn.add_css_class("flat");
-            btn.set_halign(gtk::Align::Fill);
-            if let Some(lbl) = btn.child().and_downcast::<gtk::Label>() {
-                lbl.set_xalign(0.0);
-            }
+        let item = |action: BulkAction, label: &str| -> MenuEntry {
             let s = sender.clone();
-            let p = pop.clone();
-            btn.connect_clicked(move |_| {
-                s.input(MessageListInput::Bulk(action));
-                p.popdown();
-            });
-            btn
+            MenuEntry::new(label, move || s.input(MessageListInput::Bulk(action)))
         };
 
-        let header = gtk::Label::new(Some(&format!("{count} selected")));
-        header.set_xalign(0.0);
-        header.add_css_class("dim-label");
-        header.add_css_class("caption");
-        header.set_margin_start(8);
-        header.set_margin_top(4);
-        header.set_margin_bottom(2);
-        menu.append(&header);
+        let sections = vec![
+            vec![
+                item(BulkAction::MarkRead, "Mark as Read"),
+                item(BulkAction::MarkUnread, "Mark as Unread"),
+                item(BulkAction::Flag, "Flag"),
+            ],
+            vec![
+                item(BulkAction::Spam, "Mark as Spam"),
+                item(BulkAction::Archive, "Archive"),
+                item(BulkAction::Delete, "Delete"),
+            ],
+        ];
 
-        menu.append(&item("Mark as Read", BulkAction::MarkRead));
-        menu.append(&item("Mark as Unread", BulkAction::MarkUnread));
-        menu.append(&item("Flag", BulkAction::Flag));
-        menu.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
-        menu.append(&item("Mark as Spam", BulkAction::Spam));
-        menu.append(&item("Archive", BulkAction::Archive));
-        menu.append(&item("Delete", BulkAction::Delete));
-
-        self.context_popover.set_child(Some(&menu));
-        self.context_popover
-            .set_pointing_to(Some(&gtk::gdk::Rectangle::new(x as i32, y as i32, 1, 1)));
-        self.context_popover.popup();
+        show_context_menu(self.rows.widget(), x, y, sections);
     }
 
     /// Toolbar count: total matches, noting when more exist than are shown.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,6 +3,7 @@ pub mod attachment_drawer;
 pub mod attachments_gallery;
 pub mod compose;
 pub mod contacts_browser;
+pub mod context_menu;
 pub mod message_list;
 pub mod message_view;
 pub mod message_window;

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -14,6 +14,7 @@ use gtk::prelude::*;
 use relm4::prelude::*;
 
 use crate::models::{Account, Folder, FolderKind};
+use crate::ui::context_menu::{show_context_menu, MenuEntry};
 
 /// A per-account inbox shown in the expandable "All Inboxes" sub-list.
 #[derive(Clone)]
@@ -1496,8 +1497,8 @@ fn account_initials(name: &str, email: &str) -> String {
     }
 }
 
-/// Pop up a right-click context menu of `items` anchored at (x, y) in `parent`.
-/// The popover unparents itself when dismissed (weak refs avoid a leak cycle).
+/// Pop up a right-click context menu of `items` anchored at (x, y) in
+/// `parent`, styled to GNOME HIG (sized to content, no scrollbar).
 fn show_sidebar_menu(
     parent: &impl IsA<gtk::Widget>,
     x: f64,
@@ -1505,35 +1506,16 @@ fn show_sidebar_menu(
     items: Vec<(&str, CtxAction)>,
     sender: &ComponentSender<Sidebar>,
 ) {
-    let popover = gtk::Popover::new();
-    popover.set_has_arrow(false);
-    popover.set_position(gtk::PositionType::Bottom);
-    popover.add_css_class("menu");
-
-    let menu = gtk::Box::new(gtk::Orientation::Vertical, 0);
-    menu.add_css_class("context-menu");
-    for (label, action) in items {
-        let btn = gtk::Button::with_label(label);
-        btn.add_css_class("flat");
-        btn.set_halign(gtk::Align::Fill);
-        if let Some(lbl) = btn.child().and_downcast::<gtk::Label>() {
-            lbl.set_xalign(0.0);
-        }
-        let s = sender.clone();
-        let weak = popover.downgrade();
-        btn.connect_clicked(move |_| {
-            let _ = s.output(SidebarOutput::Context(action.clone()));
-            if let Some(p) = weak.upgrade() {
-                p.popdown();
-            }
-        });
-        menu.append(&btn);
-    }
-    popover.set_child(Some(&menu));
-    popover.set_parent(parent);
-    popover.set_pointing_to(Some(&gtk::gdk::Rectangle::new(x as i32, y as i32, 1, 1)));
-    popover.connect_closed(|p| p.unparent());
-    popover.popup();
+    let entries = items
+        .into_iter()
+        .map(|(label, action)| {
+            let s = sender.clone();
+            MenuEntry::new(label, move || {
+                let _ = s.output(SidebarOutput::Context(action.clone()));
+            })
+        })
+        .collect();
+    show_context_menu(parent, x, y, vec![entries]);
 }
 
 /// A row in the "All Inboxes" sub-list: a small account pill, the account name,


### PR DESCRIPTION
A couple of changes in this:
- Create a shared builder for context menus for all areas across the app
- Bring right-click menus visually closer to GNOME HIG standards

<img width="284" height="475" alt="Screenshot From 2026-08-26 22-40-44" src="https://github.com/user-attachments/assets/62ee916b-3b80-4260-8262-f170e90fff74" />



This is part of the discussion from issue https://github.com/hyprlab/vireo/issues/62