### PR TITLE
Adjust layout and buttons for more logical flow

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -411,6 +411,8 @@ pub enum AppMsg {
     FolderNodeCollapsed { account_id: u32, path: String, collapsed: bool },
     ToggleCustomFolders(u32),
     SidebarCollapsed(bool),
+    /// The header's collapse/expand toggle (beside the hamburger) was clicked.
+    ToggleSidebarCollapse,
     /// The narrow-window breakpoint applied/unapplied — collapse the sidebar to
     /// its icon rail (and restore it) without touching the user's preference.
     AutoRail(bool),
@@ -808,14 +810,17 @@ impl SimpleComponent for AppModel {
                                     set_ellipsize: gtk::pango::EllipsizeMode::End,
                                     add_css_class: "pane-title",
                                 },
-                                // Compose leads this header: it is the window's
-                                // primary action and sits directly above the list
-                                // of messages it adds to.
+                                #[name = "sidebar_collapse_btn"]
                                 pack_start = &gtk::Button {
-                                    set_icon_name: "co.hyprlab.Vireo-mail-message-new-symbolic",
-                                    set_tooltip_text: Some("Compose"),
-                                    add_css_class: "suggested-action",
-                                    connect_clicked[sender] => move |_| sender.input(AppMsg::Compose),
+                                    set_icon_name: "co.hyprlab.Vireo-sidebar-show-symbolic",
+                                    add_css_class: "flat",
+                                    #[watch]
+                                    set_tooltip_text: Some(if model.rail_active {
+                                        "Expand sidebar"
+                                    } else {
+                                        "Collapse sidebar"
+                                    }),
+                                    connect_clicked[sender] => move |_| sender.input(AppMsg::ToggleSidebarCollapse),
                                 },
                                 pack_start = &gtk::Button {
                                     set_tooltip_text: Some("Status Bar"),
@@ -845,12 +850,6 @@ impl SimpleComponent for AppModel {
                                             add_css_class: "needs-attention",
                                         },
                                     },
-                                },
-                                pack_start = &gtk::Button {
-                                    set_icon_name: "co.hyprlab.Vireo-x-office-address-book-symbolic",
-                                    set_tooltip_text: Some("Open Contacts"),
-                                    add_css_class: "flat",
-                                    connect_clicked[sender] => move |_| sender.input(AppMsg::OpenContacts),
                                 },
                                 pack_end = &gtk::Button {
                                     set_tooltip_text: Some("Refresh"),
@@ -977,6 +976,14 @@ impl SimpleComponent for AppModel {
                                     #[watch]
                                     set_sensitive: model.current.is_some(),
                                     connect_clicked[sender] => move |_| sender.input(AppMsg::AddToContacts),
+                                },
+                                pack_start = &gtk::Button {
+                                    set_icon_name: "co.hyprlab.Vireo-x-office-address-book-symbolic",
+                                    set_tooltip_text: Some("Open Contacts"),
+                                    add_css_class: "flat",
+                                    #[watch]
+                                    set_visible: !model.showing_outbox && !model.reader_actions_collapsed,
+                                    connect_clicked[sender] => move |_| sender.input(AppMsg::OpenContacts),
                                 },
                                 pack_start = &gtk::Button {
                                     set_tooltip_text: Some("Flag"),
@@ -1323,6 +1330,7 @@ impl SimpleComponent for AppModel {
             .launch(SidebarInit { collapsed: icon_only, show_attachments })
             .forward(sender.input_sender(), |out| match out {
                 SidebarOutput::UnifiedSelected => AppMsg::UnifiedSelected,
+                SidebarOutput::ComposeClicked => AppMsg::Compose,
                 SidebarOutput::AttachmentsSelected => AppMsg::ShowAttachments,
                 SidebarOutput::OutboxSelected => AppMsg::ShowOutbox,
                 SidebarOutput::FolderSelected { account_id, folder_id, name, path } => {
@@ -1330,7 +1338,6 @@ impl SimpleComponent for AppModel {
                 }
                 SidebarOutput::ToggleCollapse(id) => AppMsg::ToggleCollapse(id),
                 SidebarOutput::ToggleCustomFolders(id) => AppMsg::ToggleCustomFolders(id),
-                SidebarOutput::CollapsedChanged(collapsed) => AppMsg::SidebarCollapsed(collapsed),
                 SidebarOutput::FolderNodeCollapsed { account_id, path, collapsed } => {
                     AppMsg::FolderNodeCollapsed { account_id, path, collapsed }
                 }
@@ -2251,6 +2258,12 @@ impl SimpleComponent for AppModel {
                     self.compact_sidebar_header(collapsed);
                     self.save_sidebar_state();
                 }
+            }
+
+            AppMsg::ToggleSidebarCollapse => {
+                let collapsed = !self.rail_active;
+                self.sidebar.emit(SidebarInput::SetCollapsed(collapsed));
+                sender.input(AppMsg::SidebarCollapsed(collapsed));
             }
 
             AppMsg::AutoRail(on) => {
@@ -4562,7 +4575,6 @@ impl AppModel {
         self.sidebar_peek = false;
         self.sidebar_collapsed = false;
         self.rail_active = false;
-        self.sidebar.emit(SidebarInput::SetPeeking(false));
         self.sidebar.emit(SidebarInput::SetCollapsed(false));
         self.peek_transition.set(true);
         split.set_collapsed(false);
@@ -4612,7 +4624,7 @@ impl AppModel {
     /// Open or close the narrow-window sidebar *peek*: the expanded sidebar
     /// floating above the panes as an overlay (the split view's collapsed
     /// mode), so neither the message list nor the reader is resized. `sync_rows`
-    /// also switches the sidebar component's rows — the sidebar's own toggle
+    /// also switches the sidebar component's rows — the header's own toggle
     /// button has already done that itself, an outside dismissal has not.
     fn set_sidebar_peek(&mut self, open: bool, sync_rows: bool, animate: bool) {
         let Some(split) = self.sidebar_split.clone() else { return };
@@ -4646,9 +4658,6 @@ impl AppModel {
             if sync_rows {
                 self.sidebar.emit(SidebarInput::SetCollapsed(false));
             }
-            // The footer toggle holds the rail's spot while floating, like
-            // the hamburger above it.
-            self.sidebar.emit(SidebarInput::SetPeeking(true));
             self.peek_sidebar_header();
             split.set_min_sidebar_width(280.0);
             split.set_max_sidebar_width(280.0);
@@ -4683,7 +4692,6 @@ impl AppModel {
                 let ghost = self.peek_rail_ghost.clone();
                 move || {
                     close_timer.borrow_mut().take();
-                    let _ = sidebar_sender.send(SidebarInput::SetPeeking(false));
                     if sync_rows {
                         let _ = sidebar_sender.send(SidebarInput::SetCollapsed(true));
                     }
@@ -4982,6 +4990,7 @@ impl AppModel {
                 ],
                 vec![
                     entry!("Add to Contacts", "contact-new", AppMsg::AddToContacts, has_current),
+                    entry!("Open Contacts", "x-office-address-book", AppMsg::OpenContacts, true),
                     if starred {
                         entry!("Remove Flag", "non-starred", AppMsg::ToggleStar, has_current)
                     } else {

--- a/src/styles.css
+++ b/src/styles.css
@@ -34,8 +34,7 @@
 
 /* Icon-only rail: tighten the sidebar header's padding so it stops forcing the
    rail wider than SIDEBAR_RAIL_WIDTH. The menu button keeps its normal size —
-   Compose used to share this header and the two together needed shrinking to
-   fit; alone, the button has room to spare in the 80px rail. */
+   alone, it has room to spare in the 80px rail. */
 headerbar.rail-header {
   padding-left: 2px;
   padding-right: 2px;
@@ -233,6 +232,19 @@ headerbar.rail-header {
 
 .folder-icon {
   opacity: 0.75;
+}
+
+/* The sidebar's Compose row: an accent-coloured pill button, inset from the
+   row edges and narrower than the rows below it, so it stands out as an
+   action rather than reading as another entry in the folder list. */
+.compose-row-btn {
+  margin: 6px 14px;
+  padding: 8px 12px;
+  border-radius: 9px;
+}
+
+.compose-row-btn label {
+  font-weight: 600;
 }
 
 /* Subtle "+ Add Folder" button under each account's folder list, aligned with
@@ -840,20 +852,7 @@ headerbar.rail-header {
   background: transparent;
 }
 
-/* ---- Sidebar footer / reorder ---- */
-
-.sidebar-footer {
-  padding: 4px 6px;
-  border-top: 1px solid alpha(currentColor, 0.08);
-}
-
-/* The footer's expand/collapse toggle: a standard icon button, right-aligned
-   in the footer when the sidebar is expanded and centred (by halign) when it
-   is a rail. */
-.sidebar-collapse-btn {
-  padding: 6px 8px;
-  min-width: 0;
-}
+/* ---- Sidebar reorder ---- */
 
 .reorder-row {
   padding: 10px 8px;

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -102,9 +102,6 @@ pub struct Sidebar {
     selected: Sel,
     /// Icon-only mode: hide all text, show just icons and account pills.
     collapsed: bool,
-    /// The floating hover-peek is on screen (rows expanded, toggle held at
-    /// the rail's spot).
-    peeking: bool,
     /// Whether the "Attachments" row is shown.
     show_attachments: bool,
     /// How many messages are waiting in the Outbox across all accounts. The row
@@ -153,15 +150,9 @@ pub enum SidebarInput {
     /// Toggle the "All Inboxes" per-account inbox sub-list.
     ToggleUnifiedExpand,
     ToggleCollapseLocal(u32),
-    /// Set icon-only mode outright (the app's narrow-window breakpoint) —
-    /// unlike ToggleCollapsed this never reports CollapsedChanged, so it can't
-    /// overwrite the user's own persisted choice.
+    /// Set icon-only mode (the user's own toggle or the app's narrow-window
+    /// breakpoint both drive this — the app owns the persisted preference).
     SetCollapsed(bool),
-    /// The floating hover-peek is on screen: rows are expanded, but the
-    /// expand/collapse toggle holds the rail's spot (like the hamburger in
-    /// the header) so it doesn't jump under an approaching cursor. Cleared
-    /// when the peek closes or is pinned into the normal expanded pane.
-    SetPeeking(bool),
     /// Toggle the collapsible "Folders" (custom folders) section for an account.
     ToggleCustomFoldersLocal(u32),
     /// Collapse/expand one folder-tree node (a parent folder's chevron, #51).
@@ -169,7 +160,6 @@ pub enum SidebarInput {
     /// A custom-folder row was clicked (fires every click, selected or not):
     /// parents toggle their sub-tree without needing the caret.
     FolderRowActivated { account_id: u32, index: i32 },
-    ToggleCollapsed,
     /// Show or hide the "Attachments" row.
     SetShowAttachments(bool),
     /// How many messages are waiting to be sent; 0 hides the Outbox row.
@@ -194,6 +184,8 @@ pub enum SidebarOutput {
     /// A folder was dropped onto a new parent ("" = the account's top level).
     MoveFolder { account_id: u32, path: String, dest: String },
     UnifiedSelected,
+    /// The "Compose" row was clicked.
+    ComposeClicked,
     /// The attachments gallery was selected.
     AttachmentsSelected,
     OutboxSelected,
@@ -206,8 +198,6 @@ pub enum SidebarOutput {
     ToggleCollapse(u32),
     /// The user toggled the collapsible custom-folders section for an account.
     ToggleCustomFolders(u32),
-    /// The user toggled icon-only mode; `true` means collapsed.
-    CollapsedChanged(bool),
     /// The empty-state "Add first account" button was clicked.
     AddAccount,
     /// A right-click context-menu action from a sidebar item.
@@ -280,25 +270,6 @@ impl Component for Sidebar {
                 },
             },
 
-            gtk::Box {
-                add_css_class: "sidebar-footer",
-                set_orientation: gtk::Orientation::Horizontal,
-
-                #[name = "collapse_btn"]
-                gtk::Button {
-                    set_icon_name: "co.hyprlab.Vireo-sidebar-show-symbolic",
-                    set_tooltip_text: Some("Collapse sidebar"),
-                    // A standard icon button, not a full-width strip:
-                    // right-aligned in the footer when expanded, centred like
-                    // the rail icons when collapsed (see the halign switches
-                    // alongside the tooltip updates).
-                    set_hexpand: true,
-                    set_halign: gtk::Align::End,
-                    add_css_class: "flat",
-                    add_css_class: "sidebar-collapse-btn",
-                    connect_clicked => SidebarInput::ToggleCollapsed,
-                },
-            },
         }
     }
 
@@ -337,7 +308,6 @@ impl Component for Sidebar {
             color_provider,
             selected: Sel::None,
             collapsed: init.collapsed,
-            peeking: false,
             show_attachments: init.show_attachments,
             outbox_count: 0,
             unified_unread: 0,
@@ -364,11 +334,6 @@ impl Component for Sidebar {
         {
             viewport.set_scroll_to_focus(false);
         }
-        if init.collapsed {
-            widgets.collapse_btn.set_tooltip_text(Some("Expand sidebar"));
-            align_collapse_btn(&widgets.collapse_btn, true, false);
-        }
-
         ComponentParts { model, widgets }
     }
 
@@ -588,39 +553,14 @@ impl Component for Sidebar {
             }
 
             SidebarInput::SetCollapsed(collapsed) => {
-                // Driven by the app's narrow-window breakpoint: same visual
-                // change as the user's own toggle, but no CollapsedChanged
-                // output — automatic switches must not overwrite the user's
-                // persisted preference.
+                // Driven by the app: either the header's collapse toggle or
+                // the narrow-window breakpoint — the app owns the persisted
+                // preference either way, so there is nothing to report back.
                 if self.collapsed != collapsed {
                     self.collapsed = collapsed;
-                    align_collapse_btn(&widgets.collapse_btn, self.collapsed, self.peeking);
-                    widgets.collapse_btn.set_tooltip_text(Some(if self.collapsed {
-                        "Expand sidebar"
-                    } else {
-                        "Collapse sidebar"
-                    }));
                     self.rebuild_normal(&widgets.normal_box, &sender);
                     self.restore_selection();
                 }
-            }
-
-            SidebarInput::SetPeeking(on) => {
-                self.peeking = on;
-                align_collapse_btn(&widgets.collapse_btn, self.collapsed, self.peeking);
-            }
-
-            SidebarInput::ToggleCollapsed => {
-                self.collapsed = !self.collapsed;
-                align_collapse_btn(&widgets.collapse_btn, self.collapsed, self.peeking);
-                widgets.collapse_btn.set_tooltip_text(Some(if self.collapsed {
-                    "Expand sidebar"
-                } else {
-                    "Collapse sidebar"
-                }));
-                self.rebuild_normal(&widgets.normal_box, &sender);
-                self.restore_selection();
-                let _ = sender.output(SidebarOutput::CollapsedChanged(self.collapsed));
             }
 
             SidebarInput::ToggleCollapseLocal(id) => {
@@ -1095,6 +1035,34 @@ impl Sidebar {
                 self.unified_revealer = Some(revealer);
                 self.unified_inbox_list = Some(sub);
             }
+        }
+
+        // "Compose" row — the window's primary action. An action button, not a
+        // navigation destination, so it is a plain Button (not a ListBox row):
+        // clicking it opens a compose window without changing what is selected.
+        // Accent-coloured and inset from the row edges (see `.compose-row-btn`
+        // in the stylesheet) so it reads as a button, not another folder row.
+        {
+            let compose_btn = gtk::Button::new();
+            compose_btn.add_css_class("suggested-action");
+            compose_btn.add_css_class("compose-row-btn");
+            let hbox = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+            hbox.set_halign(gtk::Align::Center);
+            let img = gtk::Image::from_icon_name("co.hyprlab.Vireo-mail-message-new-symbolic");
+            if self.collapsed {
+                compose_btn.set_tooltip_text(Some("Compose"));
+                hbox.append(&img);
+            } else {
+                hbox.append(&img);
+                let label = gtk::Label::new(Some("Compose"));
+                hbox.append(&label);
+            }
+            compose_btn.set_child(Some(&hbox));
+            let cs = sender.clone();
+            compose_btn.connect_clicked(move |_| {
+                let _ = cs.output(SidebarOutput::ComposeClicked);
+            });
+            container.append(&compose_btn);
         }
 
         // "Attachments" row — a gallery of every inbox attachment. Sits under the
@@ -1901,22 +1869,6 @@ fn hidden_by_collapse(
     collapsed.iter().any(|p| path_is_under(path, p))
 }
 
-/// Place the footer's expand/collapse toggle: right-aligned in the expanded
-/// sidebar, centred on the rail, and — while the floating hover-peek is up —
-/// held at the rail's spot (left, centred over the rail's 80px strip, less
-/// the footer's 6px padding) so it doesn't jump under an approaching cursor,
-/// matching the header's hamburger. Right alignment returns only when the
-/// sidebar is pinned into the real expanded pane.
-fn align_collapse_btn(btn: &gtk::Button, collapsed: bool, peeking: bool) {
-    if peeking {
-        btn.set_halign(gtk::Align::Start);
-        let w = btn.width().max(32);
-        btn.set_margin_start((((80 - w) / 2) - 6).max(0));
-    } else {
-        btn.set_margin_start(0);
-        btn.set_halign(if collapsed { gtk::Align::Center } else { gtk::Align::End });
-    }
-}
 
 /// Pop up a right-click context menu of `items` anchored at (x, y) in
 /// `parent`, styled to GNOME HIG (sized to content, no scrollbar).


### PR DESCRIPTION
- Moved the **Compose** button to the sidebar. It matches the accent color, and is more prominent and visible. It collapses down into a nice button when the sidebar is closed.
- Moved the **Open contacts** next to the **Add sender to contacts** button. Now the contacts related buttons are near each other.
- **Hamburger** menu (3 lines) remains in the sidebar. It keeps its original behavior when sidebar is collapsed.
- **Sidebar** toggle button is moved to the second pane in the top header. This makes sense logically, I believe.

This makes the layout flow more logically, and visually looks cleaner. This is in reference to https://github.com/hyprlab/vireo/issues/62.