### PR TITLE
fix: specify `--user` flag for local flatpak installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ signed Flatpak repo. Installing from the repo picks the right architecture on
 its own:
 
 ```sh
-flatpak install --from https://vireo.hyprlab.co/flatpak/co.hyprlab.Vireo.flatpakref
+flatpak install --user --from https://vireo.hyprlab.co/flatpak/co.hyprlab.Vireo.flatpakref
 ```
 
 Prefer a direct download? Each release carries `Vireo-x86_64.flatpak` and
 `Vireo-aarch64.flatpak`; grab the one matching `uname -m` from the
 [latest release](https://github.com/hyprlab/vireo/releases/latest) and run
-`flatpak install ./Vireo-*.flatpak` — the bundle carries the repo address and
+`flatpak install --user ./Vireo-*.flatpak` — the bundle carries the repo address and
 signing key, so it still receives updates from the official repo. (A bundle
 holds a single architecture; the repo above holds both.)
 


### PR DESCRIPTION
Unless specified by the `--user` flag, any non-Flathub installation will ask user for root permissions (which is fundamentally antithetical to Flathub's local sandboxing)