### PR TITLE
List a small attachment the sender declared, Content-ID and all

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2441,7 +2441,21 @@ fn extract_attachments(raw: &[u8]) -> Vec<crate::models::Attachment> {
     for (i, part) in parsed.attachments().enumerate() {
         // Decoration referenced from the body (a `cid:` logo) is rendered in
         // place, not listed — unless it's big enough to be real content.
-        if part.content_id().is_some() && part.contents().len() < INLINE_ATTACHMENT_MIN {
+        //
+        // A part the sender marked `Content-Disposition: attachment` is never
+        // decoration, however small. Gmail's composer stamps a Content-ID
+        // (`<f_…>`) on every file it uploads, so the size test alone silently
+        // dropped real attachments under 64 KiB: a message with two small PDFs
+        // and one large font file listed only the font. `structure_has_attachment`
+        // already tests disposition first, which is why such mail showed a
+        // paperclip and then an incomplete list — the two disagreed.
+        let declared_attachment = part
+            .content_disposition()
+            .is_some_and(|d| d.is_attachment());
+        if !declared_attachment
+            && part.content_id().is_some()
+            && part.contents().len() < INLINE_ATTACHMENT_MIN
+        {
             continue;
         }
         let name = part
@@ -8543,6 +8557,50 @@ mod tests {
     fn small_cid_image_is_still_only_decoration() {
         let raw = cid_mail_with_image_of(INLINE_ATTACHMENT_MIN - 1);
         assert!(extract_attachments(raw.as_bytes()).is_empty());
+    }
+
+    /// A message in the shape Gmail's composer sends: every uploaded file is
+    /// marked `Content-Disposition: attachment` *and* stamped with an `<f_…>`
+    /// Content-ID, whatever its size.
+    fn gmail_mail_with_files(files: &[(&str, &str, usize)]) -> String {
+        let mut raw = String::from("Content-Type: multipart/mixed; boundary=M\r\n");
+        raw.push_str("Subject: files\r\n\r\n");
+        raw.push_str("--M\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n");
+        raw.push_str("Body text.\r\n");
+        for (i, (name, ctype, bytes)) in files.iter().enumerate() {
+            raw.push_str("--M\r\n");
+            raw.push_str(&format!("Content-Type: {ctype}; name=\"{name}\"\r\n"));
+            raw.push_str(&format!(
+                "Content-Disposition: attachment; filename=\"{name}\"\r\n"
+            ));
+            raw.push_str("Content-Transfer-Encoding: base64\r\n");
+            raw.push_str(&format!("Content-ID: <f_a1b2c3d4{i}>\r\n\r\n"));
+            raw.push_str(&crate::oauth::base64_encode(&vec![0u8; *bytes]));
+            raw.push_str("\r\n");
+        }
+        raw.push_str("--M--\r\n");
+        raw
+    }
+
+    /// Two small files and one large one are sent together; only the large one
+    /// came back, because the small parts carried a Content-ID. A part the sender
+    /// declared an attachment is never decoration, however small.
+    #[test]
+    fn small_declared_attachments_survive_their_content_id() {
+        let raw = gmail_mail_with_files(&[
+            ("first.pdf", "application/pdf", 16_384),
+            ("second.pdf", "application/pdf", 40_960),
+            ("large.bin", "application/octet-stream", INLINE_ATTACHMENT_MIN + 1),
+        ]);
+        let found = extract_attachments(raw.as_bytes());
+        let names: Vec<&str> = found.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(
+            names,
+            ["first.pdf", "second.pdf", "large.bin"],
+            "found: {names:?}"
+        );
+        assert_eq!(found[0].data.len(), 16_384);
+        assert_eq!(found[1].data.len(), 40_960);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #109.

`extract_attachments` dropped any part carrying a Content-ID and weighing under 64 KiB, to keep a newsletter's `cid:` logo out of the file list. It never looked at Content-Disposition, so a part the sender explicitly marked `attachment` was thrown away on size alone.

Gmail's composer stamps a Content-ID (`<f_…>`) on every file it uploads, whatever its type or size, so this hits ordinary mail: a message carrying two small PDFs alongside one large file lists only the large one. Anything sent from web Gmail under 64 KiB — invoices, statements, spreadsheets, screenshots — goes the same way, and nothing in the reader hints that a file is missing.

The paperclip stays on, which makes it worse to diagnose: the flag comes from `structure_has_attachment`, which tests disposition before falling back to size, and was right all along. The two halves of one rule disagreed. Exempting a declared attachment makes them agree again.

## The change

```rust
let declared_attachment = part
    .content_disposition()
    .is_some_and(|d| d.is_attachment());
if !declared_attachment
    && part.content_id().is_some()
    && part.contents().len() < INLINE_ATTACHMENT_MIN
{
    continue;
}
```

Deliberately minimal: the size heuristic keeps working for everything that did not declare itself an attachment.

## Decoration still hidden

A `cid:` logo or a signature image arrives as `Content-Disposition: inline`, not `attachment`, so the size test still hides it. The existing tests covering that path are unchanged and still pass:

- `cid_resources_are_not_listed_as_attachments`
- `small_cid_image_is_still_only_decoration`
- `large_cid_image_is_listed_as_an_attachment`

## Test

Adds `small_declared_attachments_survive_their_content_id`: a `multipart/mixed` in the shape Gmail's composer produces — every part declared `attachment` and stamped with an `<f_…>` Content-ID — with two files below the threshold and one above. Before the change it returns one attachment; after, all three.

Full suite: 248 passed, 0 failed.

## Note on already-synced mail

`attachments_checked` remembers messages whose attachments were fetched, including ones that "turned out to have none", so mail already synced by an affected build will not be re-fetched and will keep showing an incomplete list. Clearing that table on upgrade would repair existing mailboxes — happy to add it here or in a follow-up, whichever you prefer.
