### PR TITLE
Fetch a message's attachments once, not once per Gmail label

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -907,7 +907,24 @@ impl Cache {
     }
 
     /// Whether a message's attachments have already been fetched/checked.
+    ///
+    /// Gmail shows one message under every label it carries, so the same mail
+    /// arrives as INBOX + a label + All Mail. [`load_attachments`] already reads
+    /// across those copies; without the same reach here the prefetch treats each
+    /// label as unfetched and downloads the message once per label, storing a
+    /// full second and third copy of blobs it can already answer from.
+    ///
+    /// [`load_attachments`]: Self::load_attachments
     pub fn attachments_checked(&self, account_id: u32, folder_path: &str, uid: u32) -> bool {
+        if self.checked_of(account_id, folder_path, uid) {
+            return true;
+        }
+        self.sibling_copies(account_id, folder_path, uid)
+            .into_iter()
+            .any(|(p, u)| self.checked_of(account_id, &p, u))
+    }
+
+    fn checked_of(&self, account_id: u32, folder_path: &str, uid: u32) -> bool {
         self.conn
             .query_row(
                 "SELECT 1 FROM attachments_checked WHERE account_id = ?1 AND folder_path = ?2 AND uid = ?3",
@@ -1521,6 +1538,30 @@ mod tests {
         let found = c.load_attachments(1, "INBOX", 42);
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].name, "spec.pdf");
+    }
+
+    /// One message under two labels is one download, not two. `load_attachments`
+    /// already answers for every label from whichever copy was fetched, so
+    /// fetching the others only stores the same blobs again.
+    #[test]
+    fn attachments_fetched_under_one_label_count_as_fetched_for_the_others() {
+        let c = Cache::in_memory();
+        add_threaded(&c, "INBOX", 42, 500, "same@x", "");
+        add_threaded(&c, "Work", 7, 500, "same@x", "");
+        c.mark_attachments_checked(1, "Work", 7);
+
+        assert!(c.attachments_checked(1, "INBOX", 42));
+    }
+
+    /// The reach stops at the message: an unrelated mail is still unfetched.
+    #[test]
+    fn another_message_being_fetched_does_not_count_as_this_one() {
+        let c = Cache::in_memory();
+        add_threaded(&c, "INBOX", 42, 500, "mine@x", "");
+        add_threaded(&c, "Work", 7, 500, "someone-else@x", "");
+        c.mark_attachments_checked(1, "Work", 7);
+
+        assert!(!c.attachments_checked(1, "INBOX", 42));
     }
 
     /// Two different messages must never answer for each other — the fallback


### PR DESCRIPTION
Fixes #111.

Gmail shows one message under every label it carries, so the same mail arrives as INBOX + a label + All Mail. `load_attachments` already reads across those copies — `attachments_downloaded_under_one_label_answer_for_the_others` covers it — but `attachments_checked` still keyed strictly on (account, folder, uid), and `queue_attachment_prefetch` asks that one.

So each label looked unfetched: the whole message was downloaded again, and `save_attachments` wrote another full copy of the blobs under that folder. A message under three labels costs three downloads and three copies on disk for one message's files. The reader never shows them, because the read side already reaches across.

## The change

```rust
pub fn attachments_checked(&self, account_id: u32, folder_path: &str, uid: u32) -> bool {
    if self.checked_of(account_id, folder_path, uid) {
        return true;
    }
    self.sibling_copies(account_id, folder_path, uid)
        .into_iter()
        .any(|(p, u)| self.checked_of(account_id, &p, u))
}
```

The body query moves to a private `checked_of`, unchanged. No new helper and no new SQL — this is the same `sibling_copies` the body and attachment read paths already use.

## Symmetry with bodies

`run_one_body_prefetch` asks `load_body` before it connects, and `load_body` reads across labels, so a sibling's cached body ends the fetch before any network work. The attachment path was the same shape with that step missing. After this change both halves agree.

## Tests

- `attachments_fetched_under_one_label_count_as_fetched_for_the_others` — one message under two labels, marked fetched under one, reads as fetched under the other.
- `another_message_being_fetched_does_not_count_as_this_one` — a different message under a label does not count, because `sibling_copies` requires Message-ID, sender and timestamp to match.

Full suite: 249 passed, 0 failed.

## Note

This stops new duplicates. Copies already written by an earlier build stay until something clears them — a one-time sweep on upgrade would reclaim that space, happy to add it here or separately, whichever you prefer.
