### PR TITLE
Join a filename the sender split across two encoded-words

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2444,14 +2444,92 @@ fn extract_attachments(raw: &[u8]) -> Vec<crate::models::Attachment> {
         if part.content_id().is_some() && part.contents().len() < INLINE_ATTACHMENT_MIN {
             continue;
         }
-        let name = part
-            .attachment_name()
-            .map(|s| s.to_string())
+        let name = attachment_name_of(part, raw)
             .unwrap_or_else(|| format!("attachment-{}", i + 1));
         out.push(crate::models::Attachment {
             name,
             data: part.contents().to_vec(),
         });
+    }
+    out
+}
+
+/// An attachment part's filename, repaired if the sender split it across adjacent
+/// RFC 2047 encoded-words.
+///
+/// RFC 2047 §6.2 joins adjacent encoded-words separated only by linear whitespace
+/// and discards that whitespace — it is there so a long word can be folded, not as
+/// part of the text. `mail_parser` keeps the separator inside parameter values, so
+/// a file announced as
+///
+/// ```text
+/// Content-Disposition: attachment; filename="=?utf-8?q?docu?= =?utf-8?q?ment.pdf?="
+/// ```
+///
+/// arrives named `docu ment.pdf`. That is not a cosmetic problem: with no `.pdf`
+/// suffix [`guess_mime`] can't type the file, so it gets no PDF thumbnail and
+/// opens in nothing. A header folded between the encoded-words leaves a tab
+/// instead of a space, with the same result.
+///
+/// Splice such pairs in the raw header and let `mail_parser` decode the repaired
+/// version, so the charset handling stays in one place.
+fn attachment_name_of(part: &mail_parser::MessagePart<'_>, raw: &[u8]) -> Option<String> {
+    use mail_parser::{HeaderName, MessageParser, MimeHeaders};
+
+    let names = |h: &mail_parser::Header<'_>| {
+        matches!(
+            h.name,
+            HeaderName::ContentDisposition | HeaderName::ContentType
+        )
+    };
+    let plain = || part.attachment_name().map(|s| s.to_string());
+
+    let mut repaired = Vec::new();
+    let mut spliced = false;
+    for h in part.headers.iter().filter(|h| names(h)) {
+        let Some(value) = raw.get(h.offset_start..h.offset_end) else {
+            return plain();
+        };
+        let joined = splice_encoded_words(value);
+        spliced |= joined != value;
+        repaired.extend_from_slice(h.name().as_bytes());
+        repaired.push(b':');
+        repaired.extend_from_slice(&joined);
+        if !repaired.ends_with(b"\n") {
+            repaired.extend_from_slice(b"\r\n");
+        }
+    }
+    // Nothing to repair: the common case, and no second parse.
+    if !spliced {
+        return plain();
+    }
+    repaired.extend_from_slice(b"\r\n");
+    MessageParser::default()
+        .parse(&repaired)
+        .and_then(|m| m.attachment_name().map(|s| s.to_string()))
+        .or_else(plain)
+}
+
+/// Join adjacent RFC 2047 encoded-words, discarding the linear whitespace between
+/// them. Bytes are safe to scan directly: `?=`, `=?` and the whitespace are all
+/// ASCII, which never occurs inside a multi-byte UTF-8 sequence.
+fn splice_encoded_words(value: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(value.len());
+    let mut i = 0;
+    while i < value.len() {
+        if value[i..].starts_with(b"?=") {
+            let mut j = i + 2;
+            while matches!(value.get(j), Some(b' ' | b'\t' | b'\r' | b'\n')) {
+                j += 1;
+            }
+            if j > i + 2 && value[j..].starts_with(b"=?") {
+                out.extend_from_slice(b"?=");
+                i = j;
+                continue;
+            }
+        }
+        out.push(value[i]);
+        i += 1;
     }
     out
 }
@@ -8543,6 +8621,64 @@ mod tests {
     fn small_cid_image_is_still_only_decoration() {
         let raw = cid_mail_with_image_of(INLINE_ATTACHMENT_MIN - 1);
         assert!(extract_attachments(raw.as_bytes()).is_empty());
+    }
+
+    /// One attachment, its Content-Disposition supplied verbatim.
+    fn mail_with_disposition(disposition: &str) -> String {
+        format!(
+            concat!(
+                "Content-Type: multipart/mixed; boundary=B\r\n",
+                "Subject: file\r\n\r\n",
+                "--B\r\n",
+                "Content-Type: application/octet-stream\r\n",
+                "Content-Transfer-Encoding: base64\r\n",
+                "Content-Disposition: {disposition}\r\n\r\n",
+                "AAAAAA==\r\n",
+                "--B--\r\n",
+            ),
+            disposition = disposition
+        )
+    }
+
+    /// A sender split one filename across two encoded-words with a space between
+    /// them. RFC 2047 §6.2 joins those and drops the space; keeping it yields
+    /// `docu ment.pdf` — a PDF with no `.pdf` suffix, so nothing can open it.
+    #[test]
+    fn a_filename_split_across_encoded_words_is_rejoined() {
+        let raw =
+            mail_with_disposition("attachment; filename=\"=?utf-8?q?docu?= =?utf-8?q?ment.pdf?=\"");
+        let found = extract_attachments(raw.as_bytes());
+        assert_eq!(found.len(), 1, "found: {found:?}");
+        assert_eq!(found[0].name, "document.pdf");
+    }
+
+    /// The same split, folded across two lines: the separator arrives as a tab.
+    #[test]
+    fn a_filename_folded_between_encoded_words_is_rejoined() {
+        let raw = mail_with_disposition(
+            "attachment;\r\n\tfilename=\"=?utf-8?q?docu?=\r\n\t=?utf-8?q?ment.pdf?=\"",
+        );
+        let found = extract_attachments(raw.as_bytes());
+        assert_eq!(found.len(), 1, "found: {found:?}");
+        assert_eq!(found[0].name, "document.pdf");
+    }
+
+    /// `=20` is a space in the name itself, not a separator between two words.
+    #[test]
+    fn a_space_inside_one_encoded_word_is_kept() {
+        let raw = mail_with_disposition("attachment; filename=\"=?utf-8?q?my=20file.pdf?=\"");
+        let found = extract_attachments(raw.as_bytes());
+        assert_eq!(found.len(), 1, "found: {found:?}");
+        assert_eq!(found[0].name, "my file.pdf");
+    }
+
+    /// A plain filename with a space in it is nobody's business but the sender's.
+    #[test]
+    fn an_unencoded_filename_with_a_space_is_untouched() {
+        let raw = mail_with_disposition("attachment; filename=\"my file.pdf\"");
+        let found = extract_attachments(raw.as_bytes());
+        assert_eq!(found.len(), 1, "found: {found:?}");
+        assert_eq!(found[0].name, "my file.pdf");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #117.

RFC 2047 §6.2 joins adjacent encoded-words separated only by linear whitespace and discards the separator: it is there so a long word can be folded, not as part of the text. `mail_parser` decodes both words but keeps the whitespace inside parameter values, so a file announced as

```
Content-Disposition: attachment; filename="=?utf-8?q?docu?= =?utf-8?q?ment.pdf?="
```

arrives named `docu ment.pdf`. With no `.pdf` suffix `guess_mime` falls through to `application/octet-stream`, so the file draws no PDF thumbnail and opens in nothing. A header folded between the encoded-words leaves a tab instead of a space, with the same result.

## Why it happens in the raw header

Once `attachment_name()` has returned the decoded string, the encoded-word boundaries are gone — and a space in a filename is often genuine, so there is nothing left to distinguish `docu ment.pdf` from `my file.pdf`. The repair has to happen while the raw header is still in hand.

`MessagePart::headers` exposes each header's `offset_start` / `offset_end` into the raw message, so the original bytes are reachable. `attachment_name_of` splices adjacent encoded-words there and hands the repaired Content-Disposition and Content-Type back to `mail_parser`, which keeps every charset decision in one place rather than reimplementing RFC 2047 here.

The splice scan works on bytes directly: `?=`, `=?` and the whitespace are all ASCII, which never occurs inside a multi-byte UTF-8 sequence.

## Cost

The second parse only runs when a splice actually changed something, so ordinary mail pays one comparison and nothing else.

## Tests

- `a_filename_split_across_encoded_words_is_rejoined` — the space form.
- `a_filename_folded_between_encoded_words_is_rejoined` — the same split folded, so the separator is a tab.
- `a_space_inside_one_encoded_word_is_kept` — `=?utf-8?q?my=20file.pdf?=` keeps its space; that one is in the name, not between words.
- `an_unencoded_filename_with_a_space_is_untouched` — a plain `filename="my file.pdf"` is left alone.

The last two are the guard rails: the repair must not start eating real spaces.

Full suite: 251 passed, 0 failed.

## Note

Arguably this belongs in `mail_parser` rather than here — I intend to report it upstream too. The workaround is self-contained and can come out again if that lands.
