### PR TITLE
The tray's own tests build again

### DIFF
--- a/src/tray.rs
+++ b/src/tray.rs
@@ -488,7 +488,7 @@ mod tests {
     fn every_icon_renders_at_every_size() {
         for icon in [TrayIcon::Vireo, TrayIcon::EnvelopeLight, TrayIcon::EnvelopeDark] {
             for dotted in [false, true] {
-                let set = render_set(icon, dotted);
+                let set = render_set(icon, crate::app_icon::png_for(crate::app_icon::DEFAULT_ID), dotted);
                 assert_eq!(set.len(), SIZES.len(), "{icon:?} dotted={dotted}");
                 for (i, size) in SIZES.iter().enumerate() {
                     assert_eq!(set[i].width, *size);
@@ -515,8 +515,8 @@ mod tests {
     #[test]
     fn the_dot_is_red_and_only_when_asked() {
         let size = 32usize;
-        let plain = render(TrayIcon::EnvelopeLight, false, size as i32, 1.0).unwrap();
-        let dotted = render(TrayIcon::EnvelopeLight, true, size as i32, 1.0).unwrap();
+        let plain = render(TrayIcon::EnvelopeLight, crate::app_icon::png_for(crate::app_icon::DEFAULT_ID), false, size as i32, 1.0).unwrap();
+        let dotted = render(TrayIcon::EnvelopeLight, crate::app_icon::png_for(crate::app_icon::DEFAULT_ID), true, size as i32, 1.0).unwrap();
         // The dot's centre, per `render`.
         let s = size as f64;
         let r = s * 0.19;
@@ -534,7 +534,7 @@ mod tests {
     #[test]
     fn a_half_fill_leaves_a_clear_margin_and_moves_the_dot() {
         let size = 32usize;
-        let icon = render(TrayIcon::Vireo, true, size as i32, 0.5).unwrap();
+        let icon = render(TrayIcon::Vireo, crate::app_icon::png_for(crate::app_icon::DEFAULT_ID), true, size as i32, 0.5).unwrap();
         assert_eq!(icon.data.len(), size * size * 4);
         let at = |x: usize, y: usize| {
             let i = (y * size + x) * 4;


### PR DESCRIPTION
Fixes #124.

The three tests pass the build's own icon — `png_for(DEFAULT_ID)` — which is
what the running app passes for the default choice, so the rendering under
test is the rendering people actually see.

I could not watch them go green, for the reason in the issue: gdk-pixbuf in
the GNOME 50 runtime loads through glycin, whose loader needs `flatpak-spawn`,
unavailable in the plain SDK shell I ran the suite in. This is offered as the
compile fix it is; if they then fail for you as well, that is a second thing
and worth its own look.
