### PR TITLE
Pictures from the file manager land in the message, and can be resized

### DIFF
--- a/src/ui/compose.rs
+++ b/src/ui/compose.rs
@@ -802,9 +802,10 @@ impl Component for Compose {
                 let from_alias = self.accounts.get(idx).and_then(|a| a.alias_from.clone());
 
                 // Pull the HTML and a plain-text version out of the editor (async),
-                // then finish sending via SendBody.
+                // then finish sending via SendBody. The send-time reader also
+                // recuts any picture armed for it; a draft save below does not.
                 let s = sender.clone();
-                self.editor.extract(move |html, text| {
+                self.editor.extract_for_send(move |html, text| {
                     s.input(ComposeInput::SendBody {
                         html,
                         text,

--- a/src/ui/rich_editor.rs
+++ b/src/ui/rich_editor.rs
@@ -220,6 +220,31 @@ impl RichEditor {
                     0,
                 );
                 menu.insert(&webkit6::ContextMenuItem::new_separator(), 1);
+                // Sizes lead the menu: the fractions are of the writing
+                // width, which is the width the recipient reads at, so
+                // "Large" means the full column rather than some pixel count
+                // that means nothing on the other end. Dragging the corner
+                // handles does the same thing by hand.
+                let mut at = 0;
+                for (label, kind) in [
+                    ("Small", "small"),
+                    ("Medium", "medium"),
+                    ("Large", "large"),
+                    ("Original Size", "original"),
+                ] {
+                    let action =
+                        gtk::gio::SimpleAction::new(&format!("vireo-img-{kind}"), None);
+                    let v = view.clone();
+                    action.connect_activate(move |_, _| {
+                        exec(&v, &format!("window.__vireoSetImageSize('{kind}')"));
+                    });
+                    menu.insert(
+                        &webkit6::ContextMenuItem::from_gaction(&action, label, None),
+                        at,
+                    );
+                    at += 1;
+                }
+                menu.insert(&webkit6::ContextMenuItem::new_separator(), at);
             }
             let items = menu.items();
             let Some(pos) = items
@@ -341,7 +366,7 @@ impl RichEditor {
     /// Read the current body HTML asynchronously.
     pub fn extract_html(&self, cb: impl FnOnce(String) + 'static) {
         self.webview.evaluate_javascript(
-            "document.body.innerHTML",
+            "window.__vireoBodyHtml()",
             None,
             None,
             gtk::gio::Cancellable::NONE,
@@ -352,7 +377,7 @@ impl RichEditor {
     /// Read the current body HTML and a plain-text rendering asynchronously.
     pub fn extract(&self, cb: impl FnOnce(String, String) + 'static) {
         self.webview.evaluate_javascript(
-            "document.body.innerHTML + '\\u0000' + document.body.innerText",
+            "window.__vireoBodyHtml() + '\\u0000' + document.body.innerText",
             None,
             None,
             gtk::gio::Cancellable::NONE,
@@ -855,13 +880,114 @@ const PASTE_SCRIPT: &str = r#"<script>
       spellRange = null;
     }
   });
+  /* Resizing a picture. The frame and its corner handles are ordinary
+     elements in this contenteditable document — there is nowhere else to
+     put them — so they are marked `data-vireo-ui` and stripped from
+     everything the document hands back (see `__vireoBodyHtml`). They are
+     also contenteditable=false, so the caret cannot wander into them. */
+  var rsBox = null, rsImg = null;
+  function rsRemove(){ if(rsBox){ rsBox.remove(); rsBox = null; rsImg = null; } }
+  function rsPlace(){
+    if(!rsBox || !rsImg) return;
+    if(!rsImg.isConnected){ rsRemove(); return; }
+    var r = rsImg.getBoundingClientRect();
+    rsBox.style.left = (r.left + scrollX) + 'px';
+    rsBox.style.top = (r.top + scrollY) + 'px';
+    rsBox.style.width = r.width + 'px';
+    rsBox.style.height = r.height + 'px';
+  }
+  /* A width in CSS *and* in the attribute: mail clients that ignore styles
+     still honour width, and the height is left to follow so the aspect can
+     never be lost. */
+  function rsApply(img, w){
+    img.style.width = w + 'px';
+    img.style.height = 'auto';
+    img.setAttribute('width', String(w));
+    img.removeAttribute('height');
+  }
+  function rsDown(e){
+    if(!rsImg) return;
+    e.preventDefault(); e.stopPropagation();
+    var handle = e.currentTarget, img = rsImg;
+    var west = handle.dataset.corner[1] === 'w';
+    var startX = e.clientX, startW = img.getBoundingClientRect().width;
+    var maxW = document.body.clientWidth;
+    function move(ev){
+      var dx = ev.clientX - startX;
+      var w = Math.round(west ? startW - dx : startW + dx);
+      rsApply(img, Math.max(24, Math.min(w, maxW)));
+      rsPlace();
+    }
+    function up(ev){
+      handle.removeEventListener('pointermove', move);
+      handle.removeEventListener('pointerup', up);
+      try{ handle.releasePointerCapture(ev.pointerId); }catch(_){}
+    }
+    try{ handle.setPointerCapture(e.pointerId); }catch(_){}
+    handle.addEventListener('pointermove', move);
+    handle.addEventListener('pointerup', up);
+  }
+  function rsShow(img){
+    rsRemove();
+    rsImg = img;
+    rsBox = document.createElement('div');
+    rsBox.setAttribute('data-vireo-ui', 'resize');
+    rsBox.setAttribute('contenteditable', 'false');
+    rsBox.style.cssText = 'position:absolute;pointer-events:none;z-index:9;'
+      + 'outline:1px solid #3584e4;';
+    ['nw','ne','sw','se'].forEach(function(c){
+      var h = document.createElement('div');
+      h.dataset.corner = c;
+      h.style.cssText = 'position:absolute;width:11px;height:11px;'
+        + 'background:#3584e4;border:2px solid Canvas;border-radius:50%;'
+        + 'pointer-events:auto;cursor:'
+        + ((c === 'nw' || c === 'se') ? 'nwse-resize' : 'nesw-resize') + ';';
+      h.style[c[0] === 'n' ? 'top' : 'bottom'] = '-6px';
+      h.style[c[1] === 'w' ? 'left' : 'right'] = '-6px';
+      h.addEventListener('pointerdown', rsDown);
+      rsBox.appendChild(h);
+    });
+    document.body.appendChild(rsBox);
+    rsPlace();
+  }
+  /* The context menu's size entries. `original` drops the explicit width so
+     the picture falls back to its natural size, still held to the writing
+     width by the stylesheet. */
+  window.__vireoSetImageSize = function(kind){
+    var img = window.__vireoCtxImg || rsImg;
+    if(!img) return;
+    if(kind === 'original'){
+      img.style.width = ''; img.style.height = '';
+      img.removeAttribute('width'); img.removeAttribute('height');
+    } else {
+      var full = document.body.clientWidth;
+      var f = kind === 'small' ? 0.25 : (kind === 'medium' ? 0.5 : 1);
+      rsApply(img, Math.max(24, Math.round(full * f)));
+    }
+    if(img === rsImg) rsPlace(); else rsShow(img);
+  };
+  /* What the host reads instead of body.innerHTML: the same content with
+     this script's own furniture taken out. */
+  window.__vireoBodyHtml = function(){
+    var c = document.body.cloneNode(true);
+    Array.prototype.forEach.call(c.querySelectorAll('[data-vireo-ui]'),
+      function(n){ n.remove(); });
+    return c.innerHTML;
+  };
+  addEventListener('scroll', rsPlace, true);
+  addEventListener('resize', rsPlace);
+  document.addEventListener('input', rsPlace);
   /* Clicking an image selects it whole, so it can be deleted, cut, or
-     copied like any other selection. */
+     copied like any other selection, and raises its resize frame. */
   document.addEventListener('click', function(e){
     var t = e.target;
+    if(rsBox && rsBox.contains(t)) return;   // a handle, not the document
     if(t && t.tagName === 'IMG'){
       var r = document.createRange(); r.selectNode(t);
       var s = getSelection(); s.removeAllRanges(); s.addRange(r);
+      rsShow(t);
+    } else {
+      rsRemove();
     }
   });
   /* A right-click on an image selects it (like a left click) and remembers

--- a/src/ui/rich_editor.rs
+++ b/src/ui/rich_editor.rs
@@ -548,10 +548,14 @@ fn deliver_files(
                 // escape over tens of megabytes of it costs real time. Only
                 // the MIME type comes from outside.
                 let mime = js_escape(&mime);
+                let name = js_escape(
+                    &path.file_name().unwrap_or_default().to_string_lossy(),
+                );
                 exec(
                     webview,
                     &format!(
-                        "window.__vireoInsertImageURL('data:{mime};base64,{b64}','{mime}',{x},{y})"
+                        "window.__vireoInsertImageURL(\
+                         'data:{mime};base64,{b64}','{mime}','{name}',{x},{y})"
                     ),
                 );
                 took = true;
@@ -743,7 +747,7 @@ const PASTE_SCRIPT: &str = r#"<script>
      point and are given for the first of a batch only; the rest follow the
      caret the previous insert left behind. */
   var insertQ = Promise.resolve();
-  window.__vireoInsertImageURL = function(url, type, x, y){
+  window.__vireoInsertImageURL = function(url, type, name, x, y){
     insertQ = insertQ.then(function(){
       return new Promise(function(done){
         if(x !== null && document.caretRangeFromPoint){
@@ -751,8 +755,14 @@ const PASTE_SCRIPT: &str = r#"<script>
           if(r){ var s = getSelection(); s.removeAllRanges(); s.addRange(r); }
         }
         scaleUrl(url, type, function(u){
+          /* The file's own name rides along as alt, which is the only place
+             left to keep it: the picture is a data: URI by now, and the send
+             path reads this back to name the cid: part. It is also what an
+             alt attribute is for, so a recipient whose client blocks images
+             reads the filename rather than nothing. */
+          var a = name ? ' alt="' + esc(name).replace(/"/g, '&quot;') + '"' : '';
           document.execCommand('insertHTML', false,
-            '<img src="' + u + '" style="max-width:100%">');
+            '<img src="' + u + '"' + a + ' style="max-width:100%">');
           done();
         });
       });

--- a/src/ui/rich_editor.rs
+++ b/src/ui/rich_editor.rs
@@ -244,6 +244,22 @@ impl RichEditor {
                     );
                     at += 1;
                 }
+                {
+                    let action = gtk::gio::SimpleAction::new("vireo-img-fit", None);
+                    let v = view.clone();
+                    action.connect_activate(move |_, _| {
+                        exec(&v, "window.__vireoToggleFit()");
+                    });
+                    menu.insert(
+                        &webkit6::ContextMenuItem::from_gaction(
+                            &action,
+                            "Recompress to This Size on Send",
+                            None,
+                        ),
+                        at,
+                    );
+                    at += 1;
+                }
                 menu.insert(&webkit6::ContextMenuItem::new_separator(), at);
             }
             let items = menu.items();
@@ -374,10 +390,22 @@ impl RichEditor {
         );
     }
 
+    /// Read the body for *sending*: any picture armed with "Recompress to
+    /// This Size on Send" is recut to the size it is drawn at first. Drafts
+    /// go through [`RichEditor::extract`], which never touches the pixels —
+    /// a save must not cost quality.
+    pub fn extract_for_send(&self, cb: impl FnOnce(String, String) + 'static) {
+        self.read_body("window.__vireoBodyHtmlForSend()", cb);
+    }
+
     /// Read the current body HTML and a plain-text rendering asynchronously.
     pub fn extract(&self, cb: impl FnOnce(String, String) + 'static) {
+        self.read_body("window.__vireoBodyHtml()", cb);
+    }
+
+    fn read_body(&self, reader: &str, cb: impl FnOnce(String, String) + 'static) {
         self.webview.evaluate_javascript(
-            "window.__vireoBodyHtml() + '\\u0000' + document.body.innerText",
+            &format!("{reader} + '\\u0000' + document.body.innerText"),
             None,
             None,
             gtk::gio::Cancellable::NONE,
@@ -886,7 +914,17 @@ const PASTE_SCRIPT: &str = r#"<script>
      everything the document hands back (see `__vireoBodyHtml`). They are
      also contenteditable=false, so the caret cannot wander into them. */
   var rsBox = null, rsImg = null;
+  /* Blue is an ordinary selection; red says the picture will be recut when
+     the message is sent, which is the one thing here that cannot be undone.
+     The same red the spelling underline and the tray dot use. */
+  var RS_BLUE = '#3584e4', RS_RED = '#e01b24';
   function rsRemove(){ if(rsBox){ rsBox.remove(); rsBox = null; rsImg = null; } }
+  function rsTint(){
+    if(!rsBox || !rsImg) return;
+    var c = rsImg.hasAttribute('data-vireo-fit') ? RS_RED : RS_BLUE;
+    rsBox.style.outlineColor = c;
+    Array.prototype.forEach.call(rsBox.children, function(h){ h.style.background = c; });
+  }
   function rsPlace(){
     if(!rsBox || !rsImg) return;
     if(!rsImg.isConnected){ rsRemove(); return; }
@@ -949,6 +987,7 @@ const PASTE_SCRIPT: &str = r#"<script>
     });
     document.body.appendChild(rsBox);
     rsPlace();
+    rsTint();
   }
   /* The context menu's size entries. `original` drops the explicit width so
      the picture falls back to its natural size, still held to the writing
@@ -966,13 +1005,59 @@ const PASTE_SCRIPT: &str = r#"<script>
     }
     if(img === rsImg) rsPlace(); else rsShow(img);
   };
+  /* Resizing a picture changes how big it is drawn, not how many bytes it
+     is: the full-resolution data: URI still goes out, and the recipient can
+     still save the original. Arming this asks for the bytes to be recut to
+     the size shown, once, as the message is sent — irreversible, so it is
+     off until asked for and marked on the picture while it is on. */
+  window.__vireoToggleFit = function(){
+    var img = window.__vireoCtxImg || rsImg;
+    if(!img) return;
+    if(img.hasAttribute('data-vireo-fit')){
+      img.removeAttribute('data-vireo-fit');
+      img.removeAttribute('title');
+    } else {
+      img.setAttribute('data-vireo-fit', '1');
+      img.title = 'Will be recompressed to the size shown when this is sent';
+    }
+    if(img === rsImg) rsTint(); else rsShow(img);
+  };
+  /* Recut every armed picture to the width it is drawn at. drawImage on an
+     already-loaded image and toDataURL are both synchronous, so the send
+     path can do this and read the body in one go. Enlarged pictures are left
+     alone: there are no extra pixels to be had. */
+  function rsFlatten(){
+    Array.prototype.forEach.call(
+      document.querySelectorAll('img[data-vireo-fit]'), function(im){
+        var w = Math.round(im.getBoundingClientRect().width);
+        if(!w || !im.naturalWidth || w >= im.naturalWidth) return;
+        try{
+          var c = document.createElement('canvas');
+          c.width = w;
+          c.height = Math.max(1, Math.round(w * im.naturalHeight / im.naturalWidth));
+          c.getContext('2d').drawImage(im, 0, 0, c.width, c.height);
+          var m = /^data:(image\/[a-z+]+)/.exec(im.src);
+          var type = m ? m[1] : 'image/png';
+          im.src = type === 'image/jpeg'
+            ? c.toDataURL('image/jpeg', 0.85) : c.toDataURL('image/png');
+        }catch(_){}
+      });
+  }
   /* What the host reads instead of body.innerHTML: the same content with
-     this script's own furniture taken out. */
+     this script's own furniture taken out, and the marks it reads by. */
   window.__vireoBodyHtml = function(){
     var c = document.body.cloneNode(true);
     Array.prototype.forEach.call(c.querySelectorAll('[data-vireo-ui]'),
       function(n){ n.remove(); });
+    Array.prototype.forEach.call(c.querySelectorAll('img[data-vireo-fit]'),
+      function(n){ n.removeAttribute('data-vireo-fit'); n.removeAttribute('title'); });
     return c.innerHTML;
+  };
+  /* Sending, and only sending: recut first, then read. A draft is saved
+     through the plain reader above, so quality is never lost to a save. */
+  window.__vireoBodyHtmlForSend = function(){
+    rsFlatten();
+    return window.__vireoBodyHtml();
   };
   addEventListener('scroll', rsPlace, true);
   addEventListener('resize', rsPlace);
@@ -1001,6 +1086,7 @@ const PASTE_SCRIPT: &str = r#"<script>
       window.__vireoCtxImg = t;
       var r = document.createRange(); r.selectNode(t);
       var s = getSelection(); s.removeAllRanges(); s.addRange(r);
+      rsShow(t);
     } else if(e.type === 'contextmenu'){
       window.__vireoCtxImg = null;
     }
@@ -1093,6 +1179,8 @@ fn document(content: &str, dark: bool) -> String {
               recipient; this rule is what the composer itself obeys,\
               whatever survives insertHTML. */\
            img{{max-width:100%;height:auto;}}\
+           /* A picture armed to be recut when the message is sent. */\
+           img[data-vireo-fit]{{outline:2px dashed #e01b24;outline-offset:2px;}}\
            /* The in-progress word's misspelling mark (Custom Highlight API);\
               the tint backs up engines that skip decorations in highlights. */\
            ::highlight(vireo-misspell){{\

--- a/src/ui/rich_editor.rs
+++ b/src/ui/rich_editor.rs
@@ -241,12 +241,32 @@ impl RichEditor {
                 let action =
                     gtk::gio::SimpleAction::new(if rich { "vireo-paste-rich" } else { "vireo-paste-plain" }, None);
                 let v = view.clone();
-                action.connect_activate(move |_, _| paste_into(&v, rich));
+                let cb = menu_attach_cb.clone();
+                action.connect_activate(move |_, _| paste_into(&v, rich, &cb));
                 menu.insert(&webkit6::ContextMenuItem::from_gaction(&action, label, None), at);
                 at += 1;
             }
             false
         });
+
+        // Files dropped from a file manager never reach the document: WebKitGTK
+        // hands the page a uri-list it then refuses to serve, so the drop
+        // handler in PASTE_SCRIPT sees an empty `DataTransfer.files` and lets
+        // WebKit insert the path as a link. Only the widget can see them, so
+        // the widget takes them — declaring just `GdkFileList` leaves every
+        // other drag (text, an image dragged out of the reader) to WebKit.
+        {
+            let drop =
+                gtk::DropTarget::new(gtk::gdk::FileList::static_type(), gtk::gdk::DragAction::COPY);
+            drop.set_propagation_phase(gtk::PropagationPhase::Capture);
+            let v = webview.clone();
+            let cb = attach_cb.clone();
+            drop.connect_drop(move |_, value, x, y| {
+                let Ok(list) = value.get::<gtk::gdk::FileList>() else { return false };
+                deliver_files(&v, &list.files(), Some((x, y)), &cb)
+            });
+            webview.add_controller(drop);
+        }
 
         let toolbar = build_toolbar(&webview);
 
@@ -302,7 +322,7 @@ impl RichEditor {
     /// clipboard's formatting for this one paste, whatever the standing
     /// preference says.
     pub fn paste(&self, rich: bool) {
-        paste_into(&self.webview, rich);
+        paste_into(&self.webview, rich, &self.attach_cb);
     }
 
     /// Whether the body has been edited since it was loaded (async read of a JS
@@ -453,7 +473,44 @@ fn data_uri_to_temp_file(uri: &str) -> Option<std::path::PathBuf> {
 /// the editing command once the flag is in place (the callback orders the two,
 /// since both travel to the web process asynchronously). The DOM paste handler
 /// consumes the flag — see [`PASTE_SCRIPT`].
-fn paste_into(webview: &webkit6::WebView, rich: bool) {
+///
+/// A file copied in a file manager is taken first, for the same reason the
+/// drop target exists: the clipboard offers `GdkFileList`, but by the time
+/// WebKit has turned it into a paste the document sees an empty
+/// `clipboardData` and the bare path arrives as text. The formats are checked
+/// synchronously so an ordinary text paste is not delayed by a read that was
+/// always going to fail.
+fn paste_into(
+    webview: &webkit6::WebView,
+    rich: bool,
+    cb: &std::rc::Rc<std::cell::RefCell<Option<Box<dyn Fn(std::path::PathBuf)>>>>,
+) {
+    if webview.clipboard().formats().contains_type(gtk::gdk::FileList::static_type()) {
+        let v = webview.clone();
+        let cb = cb.clone();
+        webview.clipboard().read_value_async(
+            gtk::gdk::FileList::static_type(),
+            gtk::glib::Priority::DEFAULT,
+            gtk::gio::Cancellable::NONE,
+            move |res| {
+                let taken = res
+                    .ok()
+                    .and_then(|val| val.get::<gtk::gdk::FileList>().ok())
+                    .is_some_and(|list| deliver_files(&v, &list.files(), None, &cb));
+                // Nothing usable on the clipboard after all: the ordinary
+                // paste still owes the user whatever else is on it.
+                if !taken {
+                    paste_via_webkit(&v, rich);
+                }
+            },
+        );
+        return;
+    }
+    paste_via_webkit(webview, rich);
+}
+
+/// The stock paste: arm the one-shot mode flag, then let WebKit paste.
+fn paste_via_webkit(webview: &webkit6::WebView, rich: bool) {
     let v = webview.clone();
     webview.evaluate_javascript(
         &format!("window.__vireoPasteOnce={rich};"),
@@ -462,6 +519,97 @@ fn paste_into(webview: &webkit6::WebView, rich: bool) {
         gtk::gio::Cancellable::NONE,
         move |_| v.execute_editing_command("Paste"),
     );
+}
+
+/// Images inline, everything else attached. `at` is the drop point in widget
+/// coordinates (which are the document's viewport coordinates), placing the
+/// caret where the picture was let go; a paste keeps the caret it has.
+/// Returns whether any file was taken, so a caller can fall back.
+///
+/// Reading and encoding happen here rather than in the document because the
+/// document is never given the file in the first place — see [`paste_into`].
+fn deliver_files(
+    webview: &webkit6::WebView,
+    files: &[gtk::gio::File],
+    at: Option<(f64, f64)>,
+    cb: &std::rc::Rc<std::cell::RefCell<Option<Box<dyn Fn(std::path::PathBuf)>>>>,
+) -> bool {
+    let mut took = false;
+    let mut point = at;
+    for file in files {
+        let Some(path) = file.path() else { continue };
+        match read_image_for_insert(file, &path) {
+            Some((b64, mime)) => {
+                let (x, y) = point.take().map_or(("null".into(), "null".into()), |(x, y)| {
+                    (format!("{x}"), format!("{y}"))
+                });
+                // The base64 goes in unescaped on purpose: its alphabet has
+                // nothing a JS string literal cares about, and running the
+                // escape over tens of megabytes of it costs real time. Only
+                // the MIME type comes from outside.
+                let mime = js_escape(&mime);
+                exec(
+                    webview,
+                    &format!(
+                        "window.__vireoInsertImageURL('data:{mime};base64,{b64}','{mime}',{x},{y})"
+                    ),
+                );
+                took = true;
+            }
+            // Not a picture, or too big to carry in the body: the composer's
+            // attachment list is where it belongs. Inline images are lifted
+            // into `cid:` parts at send time either way, so an attachment is
+            // the same journey with a different disposition.
+            None => match cb.borrow().as_ref() {
+                Some(f) => {
+                    f(path);
+                    took = true;
+                }
+                None => tracing::warn!("editor drop: no attach callback set on this editor"),
+            },
+        }
+    }
+    took
+}
+
+/// An image small enough to inline, as base64 of its bytes plus its MIME type.
+/// Anything else — a document, an unreadable file, or a picture so large that
+/// base64 of it would be a burden to ferry into the web process — returns
+/// `None` and becomes an attachment instead. The cap is deliberately generous:
+/// the document downscales to 1600px on insert, so the size that matters to
+/// the recipient is decided there, not here.
+fn read_image_for_insert(
+    file: &gtk::gio::File,
+    path: &std::path::Path,
+) -> Option<(String, String)> {
+    const MAX_INLINE_BYTES: u64 = 32 * 1024 * 1024;
+    let info = file
+        .query_info(
+            "standard::content-type,standard::size",
+            gtk::gio::FileQueryInfoFlags::NONE,
+            gtk::gio::Cancellable::NONE,
+        )
+        .ok()?;
+    let mime = info.content_type()?.to_string();
+    // Deliberately a list, not `image/*`: a type the engine cannot decode
+    // would insert a broken <img> carrying the whole file as base64 — a RAW
+    // photo or an HEIC off a phone is tens of megabytes of nothing. A
+    // renderable format missing from this list merely becomes an attachment,
+    // which is the harmless way to be wrong.
+    const INLINE_MIMES: &[&str] = &[
+        "image/png",
+        "image/jpeg",
+        "image/gif",
+        "image/webp",
+        "image/bmp",
+        "image/svg+xml",
+        "image/avif",
+    ];
+    if !INLINE_MIMES.contains(&mime.as_str()) || info.size() as u64 > MAX_INLINE_BYTES {
+        return None;
+    }
+    let data = std::fs::read(path).ok()?;
+    Some((crate::oauth::base64_encode(&data), mime))
 }
 
 fn build_toolbar(webview: &webkit6::WebView) -> gtk::Box {
@@ -582,8 +730,34 @@ const PASTE_SCRIPT: &str = r#"<script>
       }
       done(url);
     };
+    /* A picture the engine can't decode still has to let go of the queue
+       below, or every image after it waits forever. */
+    im.onerror = function(){ done(url); };
     im.src = url;
   }
+  /* The way in for a file the widget read for us: dropped or pasted from a
+     file manager, which the document itself never gets to see (the app's
+     drop target and paste path explain why). One queue keeps a batch in the
+     order it was dropped — each insert waits on an image decode, so parallel
+     calls would race and land backwards. `x`/`y` place the caret at the drop
+     point and are given for the first of a batch only; the rest follow the
+     caret the previous insert left behind. */
+  var insertQ = Promise.resolve();
+  window.__vireoInsertImageURL = function(url, type, x, y){
+    insertQ = insertQ.then(function(){
+      return new Promise(function(done){
+        if(x !== null && document.caretRangeFromPoint){
+          var r = document.caretRangeFromPoint(x, y);
+          if(r){ var s = getSelection(); s.removeAllRanges(); s.addRange(r); }
+        }
+        scaleUrl(url, type, function(u){
+          document.execCommand('insertHTML', false,
+            '<img src="' + u + '" style="max-width:100%">');
+          done();
+        });
+      });
+    });
+  };
   /* WebKit's own paste inserts images as blob: URLs — invisible to
      clipboardData.items, dead on the wire, and never downscaled. Convert
      every blob: image that appears, from any entry path, into the same
@@ -703,6 +877,10 @@ const PASTE_SCRIPT: &str = r#"<script>
       if(it[i].kind === 'file'){ e.preventDefault(); return; }
     }
   });
+  /* Files from a file manager are taken by the widget's drop target before
+     this runs — WebKitGTK leaves `dataTransfer.files` empty for them. What
+     reaches here is a drag that really does carry file data, such as an
+     image dragged out of another page. */
   document.addEventListener('drop', function(e){
     var fs = (e.dataTransfer && e.dataTransfer.files) || [];
     var imgs = [];

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -3079,7 +3079,11 @@ fn build_email(account: &AccountConfig, msg: &OutgoingMessage) -> Result<LettreM
         for img in images {
             let ct = ContentType::parse(&img.mime)
                 .unwrap_or_else(|_| ContentType::parse("application/octet-stream").unwrap());
-            related = related.singlepart(Attachment::new_inline(img.cid).body(img.data, ct));
+            let part = match img.name {
+                Some(name) => Attachment::new_inline_with_name(img.cid, name),
+                None => Attachment::new_inline(img.cid),
+            };
+            related = related.singlepart(part.body(img.data, ct));
         }
         related
     });
@@ -3119,6 +3123,9 @@ struct InlineImage {
     cid: String,
     mime: String,
     data: Vec<u8>,
+    /// The file's own name, when the composer knew one — carried on the
+    /// `<img>` as `alt`. Pasted image *bytes* never have one.
+    name: Option<String>,
 }
 
 /// Lift every quoted `data:image/...;base64,...` URI out of outgoing HTML
@@ -3155,10 +3162,11 @@ fn extract_data_images(html: &str) -> (String, Vec<InlineImage>) {
         match lifted {
             Some((len, mime, data)) => {
                 let cid = format!("{}.{}@vireo.inline", stamp, parts.len() + 1);
+                let name = alt_of_enclosing_tag(html, start, start + len);
                 out.push_str(&html[i..start]);
                 out.push_str("cid:");
                 out.push_str(&cid);
-                parts.push(InlineImage { cid, mime, data });
+                parts.push(InlineImage { cid, mime, data, name });
                 i = start + len;
             }
             None => {
@@ -3169,6 +3177,35 @@ fn extract_data_images(html: &str) -> (String, Vec<InlineImage>) {
     }
     out.push_str(&html[i..]);
     (out, parts)
+}
+
+/// The `alt` of the tag a lifted `data:` URI sat in — the filename the
+/// composer put there for a picture that came from a file (see the editor's
+/// insert script). The tag is delimited by the `<` before the URI and the `>`
+/// after it; anything unterminated, or a value that is not a plain filename,
+/// yields `None` and the part simply goes out unnamed as before.
+fn alt_of_enclosing_tag(html: &str, uri_start: usize, uri_end: usize) -> Option<String> {
+    let open = html[..uri_start].rfind('<')?;
+    let close = uri_end + html[uri_end..].find('>')?;
+    let tag = &html[open..close];
+    let at = tag.find("alt=")?;
+    let rest = &tag[at + "alt=".len()..];
+    let quote = rest.chars().next().filter(|c| *c == '"' || *c == '\'')?;
+    let value = &rest[quote.len_utf8()..];
+    let value = &value[..value.find(quote)?];
+    let unescaped = value
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&");
+    // Only ever a bare filename: `alt` is attacker-reachable through a quoted
+    // reply, and it ends up in a Content-Disposition header.
+    let name = std::path::Path::new(&unescaped).file_name()?.to_str()?.to_string();
+    let clean = !name.is_empty()
+        && name.len() <= 200
+        && !name.chars().any(|c| c.is_control() || c == '"' || c == '\\');
+    clean.then_some(name)
 }
 
 /// A Message-ID for outgoing mail: unique, and in the sender's own domain so it
@@ -8537,6 +8574,49 @@ mod tests {
         assert!(raw.contains("Content-Disposition: inline"), "{raw}");
         assert!(raw.contains("image/png"), "{raw}");
         assert!(!raw.contains("data:image"), "{raw}");
+    }
+
+    /// A picture dropped in from a file manager keeps the name it had; one
+    /// pasted as raw bytes has none to keep.
+    #[test]
+    fn an_images_own_filename_reaches_the_inline_part() {
+        let png = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00];
+        let uri = format!("data:image/png;base64,{}", crate::oauth::base64_encode(&png));
+        let raw_for = |img: String| {
+            let msg = OutgoingMessage {
+                to: "ada@example.com".into(),
+                body: "see picture".into(),
+                html: format!("<p>see</p>{img}"),
+                ..sample_outgoing()
+            };
+            let email = build_email(&sample_account(), &msg).expect("email builds");
+            String::from_utf8_lossy(&email.formatted()).to_string()
+        };
+        let named = raw_for(format!("<img src=\"{uri}\" alt=\"holiday snap.png\">"));
+        assert!(named.contains("holiday snap.png"), "{named}");
+        let anonymous = raw_for(format!("<img src=\"{uri}\">"));
+        assert!(anonymous.contains("Content-Disposition: inline"), "{anonymous}");
+        assert!(!anonymous.contains("filename"), "{anonymous}");
+    }
+
+    /// `alt` arrives from outside on any quoted reply and lands in a header,
+    /// so a quote, a backslash or a control character never reaches one, and
+    /// a value that is no filename at all names nothing.
+    #[test]
+    fn an_alt_that_is_not_a_plain_filename_names_nothing() {
+        let html = "<img src='data:image/png;base64,AAAA' alt='%s'>";
+        for bad in ["a\"b", "a\\b", "a\nb", "", ".", ".."] {
+            let doc = html.replace("%s", bad);
+            let (_, imgs) = extract_data_images(&doc);
+            assert_eq!(imgs.len(), 1, "{doc}");
+            assert_eq!(imgs[0].name.as_deref(), None, "{doc}");
+        }
+        // A path is not rejected but reduced: only its last segment can name
+        // the part, so a traversal cannot escape into the header.
+        let (_, ok) = extract_data_images(
+            "<img src='data:image/png;base64,AAAA' alt='../../etc/report.png'>",
+        );
+        assert_eq!(ok[0].name.as_deref(), Some("report.png"));
     }
 
     /// HTML without an embedded image keeps the old, plain alternative shape.


### PR DESCRIPTION
Closes #126, and builds the two things that turned out to be missing
alongside it.

**1. Pictures from a file manager reach the message.** A `GtkDropTarget`
declaring only `GdkFileList` takes file drags — every other drag still goes
to WebKit untouched — and the paste path checks the clipboard's formats for
a `GdkFileList` before handing the paste over, synchronously, so an ordinary
text paste is not delayed by a read that was always going to fail. Images go
inline through the same downscale-and-insert the document already uses, so
the send path lifts them into `cid:` parts exactly as before. Anything else
goes to the attachment list: a document, a picture too large to ferry into
the web process, and any image type outside a fixed list of ones the engine
is known to decode — `image/*` would let a RAW or HEIC file insert a broken
`<img>` carrying tens of megabytes of base64.

**2. A picture keeps the name its file had.** The name rides on the `<img>`
as `alt`, which is also where the reader already looks for Gmail photo mail,
and the send path names the inline part with it. Only a bare filename is
taken: `alt` arrives from outside on any quoted reply and ends up in a
Content-Disposition header, so the value is reduced to its last path segment
and one carrying a quote, a backslash or a control character names nothing.

**3. Pictures can be resized.** Clicking one raises a frame with four corner
handles; the right-click menu leads with Small, Medium, Large and Original
Size. The presets are fractions of the writing width, not pixel counts,
because that is the width the recipient reads at. Width goes to the inline
style *and* the width attribute, since clients that ignore CSS still honour
the attribute.

The frame and handles are ordinary elements — a contenteditable document has
nowhere else to put them — so they carry `data-vireo-ui`, and the body is now
read through `__vireoBodyHtml()`, which clones it and drops anything marked.
What is sent and what is saved to Drafts is byte-for-byte the content it was.

**4. Optionally, the bytes follow the size.** Resizing changes how big a
picture is drawn, not how much travels, which is the right default — nothing
is thrown away. When the point was to make the message lighter, the menu
offers *Recompress to This Size on Send*. An armed picture says so while it
waits — its frame and handles turn red, and it wears a red dashed outline
when the frame is down, blue being an ordinary selection and red the one
thing here that cannot be undone — and is recut once, as the message is sent.
Only sending does it; drafts save through the reader that never touches
pixels, so a message reopened from Drafts is still at full resolution with
its arming intact.

**Testing.** 266 tests pass, including two new ones covering the filename
path and the hostile-`alt` rejection. Drag, paste, send, and a non-image
dropped into the body were all exercised by hand against a local Flatpak
build on GNOME 50.

Three tray tests are excluded from that count because `cargo test` does not
compile on `main` at all (#124, fixed in #125); I ran the suite with those
calls fixed locally.
